### PR TITLE
[Fix/#18] `Home` 페이지 레이아웃이 깨지는 현상을 해결

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -40,7 +40,7 @@
 
 @media (max-width: 684px) {
   .articles {
-      grid-template-columns: 1fr;
+    grid-template-columns: 1fr;
   }
 }
 
@@ -90,10 +90,8 @@
 }
 
 .content {
-  height: calc(var(--text-body-2-line-height) * 2);
   overflow: hidden;
   text-overflow: ellipsis;
-  line-clamp: 2;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -101,6 +99,7 @@
   font-weight: var(--text-body-2-weight);
   line-height: var(--text-body-2-line-height);
   color: var(--theme-text-secondary);
+  word-break: break-word;
 }
 
 @media (max-width: 1324px) {


### PR DESCRIPTION
close #18 

## 주요 변경사항
 - `.content` 클래스의 내용을 두 줄로 제한하는 스타일링을 잘못 설정하여서 발생
 - 이를 해결하기 위해 `word-break` 속성 추가 및 `height` 속성 삭제