### PR TITLE
[Fix/#27] 존재하지 않는 게시물 접근 시 예외 처리 흐름 개선

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -67,7 +67,6 @@ export default async function Post({
   slug: string
 }> }) {
   const { slug } = await params;
-  const { default: Post } = await import(`../../posts/${slug}.md`);
 
   const allPosts = await AllPosts();
   const post = allPosts.find((post) => (
@@ -77,6 +76,8 @@ export default async function Post({
   if (!post) {
     notFound();
   }
+
+  const PostContent = (await import(`@/posts/${post.slug}.md`)).default;
 
   return (
     <>
@@ -136,7 +137,7 @@ export default async function Post({
               [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded-md
               [&_code]:bg-gray-100 dark:[&_code]:bg-gray-800"
             >
-              <Post />
+              <PostContent />
             </div>
           </div>
           <Giscus />


### PR DESCRIPTION
## 연관 Issue
- Closes #27

## 요약
존재하지 않는 게시물에 접근 시 게시물이 존재하는지 확인하기 전에 `/slug`의 `.md` 파일을 불러오려고 시도하는 문제를 해결했습니다.

## 작업 내용
- 게시물 메타데이터를 먼저 조회한 뒤, 해당 게시물이 존재하지 않으면 `notFound()`를 호출하도록 처리 순서를 변경
- 존재하는 게시물에 대해서만 `.md` 파일을 동적으로 import하도록 수정
- 마크다운 컴포넌트 import 변수명을 `PostContent`로 변경하여 페이지 컴포넌트 이름과의 혼동 감소

## 범위
### 포함:
- `[slug]`의 마크다운 컴포넌트 import 로직 및 시점
### 제외:
- `generateStaticParams` 및 `dynamicParams` 설정 변경
- `metadata`, Open Graph, Twitter card 관련 개선
- `next/image`의 `priority` prop 관련 변경
- MDX 설정 또는 게시물 로딩 구조 전반 리팩터링

## 스크린샷 / 미리 보기
| 수정 전 | 수정 후 |
| --- | --- |
| <img width="457" height="369" alt="스크린샷 2026-07-03 오전 12 02 07" src="https://github.com/user-attachments/assets/54a26724-9ab4-48ad-a34f-a01e3eb06caa" /> | <img width="377" height="288" alt="스크린샷 2026-07-03 오전 12 03 28" src="https://github.com/user-attachments/assets/37366773-9bfc-46c7-9b5f-3f9677bcf978" /> |