### PR TITLE
[Chore/#31] `tsconfig.json`에서 `baseUrl` 설정 제거

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "baseUrl": ".",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## 연관 Issue
- Closes #31 

## 요약
TypeScript 7.0에서 더 이상 작동하지 않는`baseUrl` 설정을 제거하도록 `tsconfig.json`을 수정하였습니다.

## 작업 내용
- `tsconfig.json`에서 `baseUrl` 설정 제거

## 범위
### 포함:
- 게시글 파일 확장자 변경
- MDX 설정 변경
- 게시글 목록 및 상세 페이지 로딩 경로 수정

### 제외:
- 게시글 본문 내용 수정
- UI/스타일 변경
- 메타데이터 및 SEO 관련 변경

## 스크린샷 / 미리 보기