### PR TITLE
[Fix/#33] SEO 개선

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -3,6 +3,6 @@ import type { MetadataRoute } from 'next';
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: { userAgent: '*', allow: '/' },
-    sitemap: "https://blog.d3h1.com/sitemap/sitemap.xml",
+    sitemap: "https://blog.d3h1.com/sitemap.xml",
   };
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,8 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: '*', allow: '/' },
+    sitemap: "https://blog.d3h1.com/sitemap/sitemap.xml",
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -8,13 +8,11 @@ export async function generateSitemaps() {
   return Array.from({ length: numberOfSitemaps }, (_, i) => ({ id: i }));
 }
 
-export default async function sitemap({
-  id
-}: {
-  id: Promise<number>
+export default async function sitemap(props: {
+  id: Promise<string>
 }): Promise<MetadataRoute.Sitemap> {
   const posts = await AllPosts();
-  const index = await id;
+  const index = Number(await props.id)
 
   const start = index * 50000;
   const end = start + 50000;

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -18,8 +18,25 @@ export async function generateSitemaps() {
 export default async function sitemap(props: {
   id: Promise<string>
 }): Promise<MetadataRoute.Sitemap> {
+  const id = await props.id;
+
+  if (id === "sitemap") {
+    const count = await getSitemapCount();
+
+    return [
+      {
+        url: "https://blog.d3h1.com",
+        lastModified: new Date(),
+      },
+      ...Array.from({ length: count }, (_, i) => ({
+        url: `https://blog.d3h1.com/sitemap/${i}.xml`,
+        lastModified: new Date(),
+      })),
+    ];
+  }
+
   const posts = await AllPosts();
-  const index = Number(await props.id)
+  const index = Number(id);
 
   const start = index * 50000;
   const end = start + 50000;

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,49 +1,23 @@
 import type { MetadataRoute } from "next";
 import AllPosts from "@/utils/allpost";
 
-async function getSitemapCount() {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const posts = await AllPosts();
-  return Math.ceil(posts.length / 50000);
-}
 
-export async function generateSitemaps() {
-  const count = await getSitemapCount();
-  
-  return [
-    { id: "sitemap" },
-    ...Array.from({ length: count }, (_, i) => ({ id: i }))
-  ];
-}
-
-export default async function sitemap(props: {
-  id: Promise<string>
-}): Promise<MetadataRoute.Sitemap> {
-  const id = await props.id;
-
-  if (id === "sitemap") {
-    const count = await getSitemapCount();
-
-    return [
-      {
-        url: "https://blog.d3h1.com",
-        lastModified: new Date(),
-      },
-      ...Array.from({ length: count }, (_, i) => ({
-        url: `https://blog.d3h1.com/sitemap/${i}.xml`,
-        lastModified: new Date(),
-      })),
-    ];
-  }
-
-  const posts = await AllPosts();
-  const index = Number(id);
-
-  const start = index * 50000;
-  const end = start + 50000;
-  const paginatedPosts = posts.slice(start, end);
-
-  return paginatedPosts.map((post) => ({
+  const postRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
     url: `https://blog.d3h1.com/${post.slug}`,
     lastModified: new Date(post.date),
+    changeFrequency: "weekly",
+    priority: 0.8,
   }));
+
+  return [
+    {
+      url: "https://blog.d3h1.com",
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 1.0,
+    },
+    ...postRoutes,
+  ];
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -18,23 +18,8 @@ export default async function sitemap(props: {
   const end = start + 50000;
   const paginatedPosts = posts.slice(start, end);
 
-  const routes: MetadataRoute.Sitemap = index === 0 
-    ? []
-    : [
-        {
-          url: "https://blog.d3h1.com",
-          lastModified: new Date(),
-          changeFrequency: "daily",
-          priority: 1.0,
-        },
-      ];
-
-  const postRoutes: MetadataRoute.Sitemap = paginatedPosts.map((post) => ({
+  return paginatedPosts.map((post) => ({
     url: `https://blog.d3h1.com/${post.slug}`,
     lastModified: new Date(post.date),
-    changeFrequency: "weekly",
-    priority: 0.8,
   }));
-
-  return [...routes, ...postRoutes];
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,11 +1,18 @@
 import type { MetadataRoute } from "next";
 import AllPosts from "@/utils/allpost";
 
-export async function generateSitemaps() {
+async function getSitemapCount() {
   const posts = await AllPosts();
-  const numberOfSitemaps = Math.ceil(posts.length / 50000);
+  return Math.ceil(posts.length / 50000);
+}
+
+export async function generateSitemaps() {
+  const count = await getSitemapCount();
   
-  return Array.from({ length: numberOfSitemaps }, (_, i) => ({ id: i }));
+  return [
+    { id: "sitemap" },
+    ...Array.from({ length: count }, (_, i) => ({ id: i }))
+  ];
 }
 
 export default async function sitemap(props: {


### PR DESCRIPTION
## 연관 Issue
- Closes #33 

## 요약
`sitemap/0.xml`처럼 사이트맵이 관리되던 방식에서 `sitemap.xml`에서 홈 URL과 하위 게시물을 모두 표시하는 방법으로 개선하고, `robots.ts`를 작성했습니다.

## 작업 내용
- `sitemap` 함수의 id 타입을 `Next.js 16`부터 변경된 `string`으로 수정
- 하위 사이트맵의 개수를 계산하는 변수를 재사용 가능한 함수로 분리
- 메인 사이트맵에서 모든 페이지를 표시하는 방법으로 개선
- `robots.ts`작성

## 범위
### 포함:
- `sitemap.ts`의 관련 로직
- `robots.ts`

### 제외:
- 게시글 관련 로직 및 타입
- 컴포넌트 및 레이아웃 UI 수정
- 배포 설정 수정
- 종속성 버전 수정

## 스크린샷 / 미리 보기
<img width="784" height="1008" alt="image" src="https://github.com/user-attachments/assets/c453018a-0bb3-46df-b02a-79c108db6f48" />
<img width="350" height="133" alt="image" src="https://github.com/user-attachments/assets/851be3bb-274f-4261-b272-031ca5d6bb76" />