### PR TITLE
[Fix/#37] `Footer` 컴포넌트에서 HTML 요소가 중첩되는 문제 해결 및 `Link` 컴포넌트 사용

### DIFF
--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import Icon from "../Icon";
 
 const socialLinks = [
@@ -22,7 +21,7 @@ export default function Footer() {
     >
       <div className="w-full flex items-center justify-center gap-4 lg:justify-between">
         {socialLinks.map((link) => (
-          <Link
+          <a
             key={link.name}
             href={link.href}
             target="_blank"
@@ -34,7 +33,7 @@ export default function Footer() {
               name={link.name}
               size={20}
             />
-          </Link>
+          </a>
         ))}
       </div>
       <div className="w-full max-w-80 lg:max-w-40

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -1,6 +1,18 @@
 import Link from "next/link";
-import Button from "../Button";
 import Icon from "../Icon";
+
+const socialLinks = [
+  { name: "instagram", href: "https://www.instagram.com/dohun0310/" },
+  { name: "facebook", href: "https://www.facebook.com/dohun0310/" },
+  { name: "x", href: "https://x.com/dohun0310/" },
+  { name: "github", href: "https://github.com/dohun0310/" },
+] as const;
+
+const socialLinkClass = `inline-flex justify-center items-center p-2
+  gap-1.5 rounded-full cursor-pointer select-none
+  bg-background text-foreground
+  border border-gray-100 dark:border-gray-800
+  hover:bg-foreground/5 transition-colors duration-300`;
 
 export default function Footer() {
   return (
@@ -9,70 +21,21 @@ export default function Footer() {
       static lg:fixed lg:right-[calc((100%-1325px)/2+16px)]"
     >
       <div className="w-full flex items-center justify-center gap-4 lg:justify-between">
-        <Link
-          href="https://www.instagram.com/dohun0310/"
-          aria-label="instagram"
-        >
-          <Button
-            size="tiny"
-            variant="linear"
-            iconOnly
-            aria-label="instagram"
+        {socialLinks.map((link) => (
+          <Link
+            key={link.name}
+            href={link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={link.name}
+            className={socialLinkClass}
           >
             <Icon
-              name="instagram"
+              name={link.name}
               size={20}
             />
-          </Button>
-        </Link>
-        <Link
-          href="https://www.facebook.com/dohun0310/"
-          aria-label="facebook"
-        >
-          <Button
-            size="tiny"
-            variant="linear"
-            iconOnly
-            aria-label="facebook"
-          >
-            <Icon
-              name="facebook"
-              size={20}
-            />
-          </Button>
-        </Link>
-        <Link
-          href="https://x.com/dohun0310/"
-          aria-label="x"
-        >
-          <Button
-            size="tiny"
-            variant="linear"
-            iconOnly
-            aria-label="x"
-          >
-            <Icon
-              name="x"
-              size={20}
-            />
-          </Button>
-        </Link>
-        <Link
-          href="https://github.com/dohun0310/"
-          aria-label="github"
-        >
-          <Button
-            size="tiny"
-            variant="linear"
-            iconOnly
-            aria-label="github"
-          >
-            <Icon
-              name="github"
-              size={20}
-            />
-          </Button>
-        </Link>
+          </Link>
+        ))}
       </div>
       <div className="w-full max-w-80 lg:max-w-40
         bg-gray-400 dark:bg-gray-700 object-contain


### PR DESCRIPTION
## 연관 Issue
- Closes #37 

## 요약
`Footer`에서 `<Link>` 또는 `<a>` 안에 `<Button>`이 중첩되는 잘못된 HTML 구조를 제거하고 `<Link>` 컴포넌트를 사용합니다.

## 작업 내용
- `components/Footer/index.tsx`의 소셜 링크 구조를 단일 `<Link>`로 변경
- 각 링크에 `target="_blank"`와 `rel="noopener noreferrer"` 추가

## 범위
### 포함:
- Footer 소셜 링크를 단일 `<Link>` 요소로 변경
- 기존 Button tiny/linear/iconOnly와 동일한 시각 스타일 재현
- 외부 링크에 `target="_blank"` 추가
- 외부 링크에 `rel="noopener noreferrer"` 추가

### 제외:
- Footer 디자인 변경
- 소셜 링크 config 분리
- copyright 문구 변경

## 스크린샷 / 미리 보기
<img width="288" height="91" alt="image" src="https://github.com/user-attachments/assets/c5c2f84b-a2e8-4346-8add-d0eb15decab3" />