### PR TITLE
[Fix/#35] 검색 다이얼로그 개선 및 게시물 카드 링크 절대 경로 변경

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -72,7 +72,7 @@ export default async function Home({
                 className="flex flex-col"
               >
                 <Link
-                  href={post.slug}
+                  href={`/${post.slug}`}
                   className="text-inherit no-underline
                   transition-colors duration-300
                   hover:p-2 hover:-m-2 hover:rounded-2xl hover:bg-foreground/5"

--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -80,7 +80,8 @@ export default function Search({
 
       switch (e.key) {
         case "Escape":
-          // ESC는 dialog가 자동으로 처리
+          e.preventDefault();
+          handleClose();
           break;
         case "ArrowDown":
           e.preventDefault();
@@ -164,7 +165,7 @@ export default function Search({
                     key={post.slug}
                     className={`w-full flex items-center gap-4 px-4 py-3
                       border-none text-left cursor-pointer hover:bg-foreground/5
-                      ${index === selectedIndex ? "bg-background/5" : ""}`}
+                      ${index === selectedIndex ? "bg-foreground/5" : ""}`}
                     onClick={() => {
                       router.push(`/${post.slug}`);
                       handleClose();

--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -1,131 +1,37 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
-import { useRouter } from "next/navigation";
 import Image from "next/image";
 import Icon from "../Icon";
 import Button from "../Button";
 import Post from "@/types/post";
-import { useSearch } from "@/contexts/SearchContext";
+import useSearchDialog from "@/hooks/search";
 
 export default function Search({
   allPosts
 }: {
   allPosts: Post[]
 }) {
-  const router = useRouter();
-
-  const dialogRef = useRef<HTMLDialogElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const isKeyboardNav = useRef(false);
-
-  const { isOpen, closeSearch } = useSearch();
-  const [searchKeyword, setSearchKeyword] = useState("");
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [displayCount, setDisplayCount] = useState(6);
-
-  const filteredPosts = allPosts.filter(
-    (post) =>
-      post.title.toLowerCase().includes(searchKeyword.toLowerCase()) ||
-      post.content.toLowerCase().includes(searchKeyword.toLowerCase())
-  );
-
-  const displayedPosts = filteredPosts.slice(0, displayCount);
-  const hasMore = filteredPosts.length > displayCount;
-
-  // dialog 열기/닫기 관리
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    if (isOpen) {
-      dialog.showModal();
-      inputRef.current?.focus();
-    } else {
-      dialog.close();
-    }
-  }, [isOpen]);
-
-  const handleClose = useCallback(() => {
-    closeSearch();
-    setSearchKeyword("");
-    setSelectedIndex(0);
-    setDisplayCount(6);
-  }, [closeSearch]);
+  const {
+    dialogRef,
+    inputRef,
+    itemRefs,
+    searchKeyword,
+    setSearchKeyword,
+    selectedIndex,
+    displayedPosts,
+    hasMore,
+    handleClose,
+    handleLoadMore,
+    handleMouseEnterItem,
+    handleMouseMove,
+    navigateToPost,
+  } = useSearchDialog(allPosts);
 
   // dialog 닫힐 때 처리
   const handleCancel = (e: React.FormEvent<HTMLDialogElement>) => {
     e.preventDefault();
     handleClose();
   }
-
-  // 배경 클릭 시 닫기
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    const handleClickOutside = (e: MouseEvent) => {
-      if (e.target === dialog) {
-        handleClose();
-      }
-    };
-
-    dialog.addEventListener("click", handleClickOutside);
-    return () => dialog.removeEventListener("click", handleClickOutside);
-  }, [handleClose]);
-
-  // 키보드 네비게이션
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (!isOpen) return;
-
-      switch (e.key) {
-        case "Escape":
-          e.preventDefault();
-          handleClose();
-          break;
-        case "ArrowDown":
-          e.preventDefault();
-          isKeyboardNav.current = true;
-          setSelectedIndex((prev) =>
-            prev < displayedPosts.length - 1 ? prev + 1 : prev
-          );
-          break;
-        case "ArrowUp":
-          e.preventDefault();
-          isKeyboardNav.current = true;
-          setSelectedIndex((prev) => (prev > 0 ? prev - 1 : 0));
-          break;
-        case "Enter":
-          e.preventDefault();
-          if (displayedPosts[selectedIndex]) {
-            router.push(`/${displayedPosts[selectedIndex].slug}`);
-            handleClose();
-          }
-          break;
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, displayedPosts, selectedIndex, router, handleClose]);
-
-  // 선택된 항목이 화면에 보이도록 스크롤
-  useEffect(() => {
-    itemRefs.current[selectedIndex]?.scrollIntoView({
-      block: "nearest",
-    });
-  }, [selectedIndex]);
-
-  useEffect(() => {
-    setSelectedIndex(0);
-    setDisplayCount(6);
-  }, [searchKeyword]);
-
-  const handleLoadMore = () => {
-    setDisplayCount((prev) => prev + 6);
-  };
 
   return (
     <dialog
@@ -135,7 +41,7 @@ export default function Search({
         backdrop:bg-background/80
         transition-colors duration-300"
       onCancel={handleCancel}
-      onMouseMove={() => { isKeyboardNav.current = false; }}
+      onMouseMove={handleMouseMove}
     >
       <div className="w-[95vw] lg:w-[90vw] max-w-160 fixed
         top-1/10 lg:top-1/5 left-1/2 -translate-x-1/2
@@ -179,14 +85,8 @@ export default function Search({
                     className={`w-full flex items-center gap-4 px-4 py-3
                       border-none text-left cursor-pointer hover:bg-foreground/5
                       ${index === selectedIndex ? "bg-foreground/5" : ""}`}
-                    onClick={() => {
-                      router.push(`/${post.slug}`);
-                      handleClose();
-                    }}
-                    onMouseEnter={() => {
-                      if (isKeyboardNav.current) return;
-                      setSelectedIndex(index);
-                    }}
+                    onClick={() => navigateToPost(post.slug)}
+                    onMouseEnter={() => handleMouseEnterItem(index)}
                   >
                     <Image
                       src={post.teaser}

--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import Icon from "../Icon";
@@ -45,17 +45,17 @@ export default function Search({
     }
   }, [isOpen]);
 
-  // dialog 닫힐 때 처리
-  const handleCancel = (e: React.FormEvent<HTMLDialogElement>) => {
-    e.preventDefault();
-    handleClose();
-  }
-
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     closeSearch();
     setSearchKeyword("");
     setSelectedIndex(0);
     setDisplayCount(6);
+  }, [closeSearch]);
+
+  // dialog 닫힐 때 처리
+  const handleCancel = (e: React.FormEvent<HTMLDialogElement>) => {
+    e.preventDefault();
+    handleClose();
   }
 
   // 배경 클릭 시 닫기

--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -17,6 +17,8 @@ export default function Search({
 
   const dialogRef = useRef<HTMLDialogElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const isKeyboardNav = useRef(false);
 
   const { isOpen, closeSearch } = useSearch();
   const [searchKeyword, setSearchKeyword] = useState("");
@@ -62,13 +64,13 @@ export default function Search({
   useEffect(() => {
     const dialog = dialogRef.current;
     if (!dialog) return;
-    
+
     const handleClickOutside = (e: MouseEvent) => {
       if (e.target === dialog) {
         handleClose();
       }
     };
-    
+
     dialog.addEventListener("click", handleClickOutside);
     return () => dialog.removeEventListener("click", handleClickOutside);
   }, [handleClose]);
@@ -85,12 +87,14 @@ export default function Search({
           break;
         case "ArrowDown":
           e.preventDefault();
+          isKeyboardNav.current = true;
           setSelectedIndex((prev) =>
             prev < displayedPosts.length - 1 ? prev + 1 : prev
           );
           break;
         case "ArrowUp":
           e.preventDefault();
+          isKeyboardNav.current = true;
           setSelectedIndex((prev) => (prev > 0 ? prev - 1 : 0));
           break;
         case "Enter":
@@ -105,7 +109,14 @@ export default function Search({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, displayedPosts, selectedIndex, router]);
+  }, [isOpen, displayedPosts, selectedIndex, router, handleClose]);
+
+  // 선택된 항목이 화면에 보이도록 스크롤
+  useEffect(() => {
+    itemRefs.current[selectedIndex]?.scrollIntoView({
+      block: "nearest",
+    });
+  }, [selectedIndex]);
 
   useEffect(() => {
     setSelectedIndex(0);
@@ -124,6 +135,7 @@ export default function Search({
         backdrop:bg-background/80
         transition-colors duration-300"
       onCancel={handleCancel}
+      onMouseMove={() => { isKeyboardNav.current = false; }}
     >
       <div className="w-[95vw] lg:w-[90vw] max-w-160 fixed
         top-1/10 lg:top-1/5 left-1/2 -translate-x-1/2
@@ -163,6 +175,7 @@ export default function Search({
                 {displayedPosts.map((post, index) => (
                   <button
                     key={post.slug}
+                    ref={(el) => { itemRefs.current[index] = el; }}
                     className={`w-full flex items-center gap-4 px-4 py-3
                       border-none text-left cursor-pointer hover:bg-foreground/5
                       ${index === selectedIndex ? "bg-foreground/5" : ""}`}
@@ -170,7 +183,10 @@ export default function Search({
                       router.push(`/${post.slug}`);
                       handleClose();
                     }}
-                    onMouseEnter={() => setSelectedIndex(index)}
+                    onMouseEnter={() => {
+                      if (isKeyboardNav.current) return;
+                      setSelectedIndex(index);
+                    }}
                   >
                     <Image
                       src={post.teaser}

--- a/hooks/search.ts
+++ b/hooks/search.ts
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Post from "@/types/post";
+import { useSearch } from "@/contexts/SearchContext";
+
+export default function useSearchDialog(allPosts: Post[]) {
+  const router = useRouter();
+
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const isKeyboardNav = useRef(false);
+
+  const { isOpen, closeSearch } = useSearch();
+  const [searchKeyword, setSearchKeyword] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [displayCount, setDisplayCount] = useState(6);
+
+  const filteredPosts = allPosts.filter(
+    (post) =>
+      post.title.toLowerCase().includes(searchKeyword.toLowerCase()) ||
+      post.content.toLowerCase().includes(searchKeyword.toLowerCase())
+  );
+
+  const displayedPosts = filteredPosts.slice(0, displayCount);
+  const hasMore = filteredPosts.length > displayCount;
+
+  // dialog 열기/닫기 관리
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (isOpen) {
+      dialog.showModal();
+      inputRef.current?.focus();
+    } else {
+      dialog.close();
+    }
+  }, [isOpen]);
+
+  const handleClose = useCallback(() => {
+    closeSearch();
+    setSearchKeyword("");
+    setSelectedIndex(0);
+    setDisplayCount(6);
+  }, [closeSearch]);
+
+  const navigateToPost = useCallback((slug: string) => {
+    router.push(`/${slug}`);
+    handleClose();
+  }, [router, handleClose]);
+
+  // 배경 클릭 시 닫기
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (e.target === dialog) {
+        handleClose();
+      }
+    };
+
+    dialog.addEventListener("click", handleClickOutside);
+    return () => dialog.removeEventListener("click", handleClickOutside);
+  }, [handleClose]);
+
+  // 키보드 네비게이션
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!isOpen) return;
+
+      switch (e.key) {
+        case "Escape":
+          e.preventDefault();
+          handleClose();
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          isKeyboardNav.current = true;
+          setSelectedIndex((prev) =>
+            prev < displayedPosts.length - 1 ? prev + 1 : prev
+          );
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          isKeyboardNav.current = true;
+          setSelectedIndex((prev) => (prev > 0 ? prev - 1 : 0));
+          break;
+        case "Enter":
+          e.preventDefault();
+          if (displayedPosts[selectedIndex]) {
+            navigateToPost(displayedPosts[selectedIndex].slug);
+          }
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, displayedPosts, selectedIndex, handleClose, navigateToPost]);
+
+  // 선택된 항목이 화면에 보이도록 스크롤
+  useEffect(() => {
+    itemRefs.current[selectedIndex]?.scrollIntoView({
+      block: "nearest",
+    });
+  }, [selectedIndex]);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+    setDisplayCount(6);
+  }, [searchKeyword]);
+
+  const handleLoadMore = () => {
+    setDisplayCount((prev) => prev + 6);
+  };
+
+  const handleMouseEnterItem = (index: number) => {
+    if (isKeyboardNav.current) return;
+    setSelectedIndex(index);
+  };
+
+  const handleMouseMove = () => {
+    isKeyboardNav.current = false;
+  };
+
+  return {
+    dialogRef,
+    inputRef,
+    itemRefs,
+    searchKeyword,
+    setSearchKeyword,
+    selectedIndex,
+    displayedPosts,
+    hasMore,
+    handleClose,
+    handleLoadMore,
+    handleMouseEnterItem,
+    handleMouseMove,
+    navigateToPost,
+  };
+}


### PR DESCRIPTION
## 연관 Issue
- Closes #35 

## 요약
검색 다이얼로그의 키보드 네비게이션 동작을 개선하고, 선택된 검색 결과가 더 명확하게 보이도록 하이라이트 색상을 수정했습니다.

또한 검색 결과를 키보드로 이동할 때 선택된 항목이 스크롤 영역 안에 보이도록 처리하고, 홈 카드 링크를 명시적인 절대 경로로 변경했습니다.

## 작업 내용
- `components/Search/index.tsx`에서 `handleClose`를 `useCallback`으로 변경
- `handleCancel`이 안정화된 `handleClose`를 사용하도록 선언 순서 정리
- dialog 외부 클릭 이벤트 effect의 의존성에 `handleClose` 반영
- ESC 키 입력 시 `handleClose`를 직접 호출하도록 변경
- 검색 결과 선택 하이라이트 클래스를 `bg-background/5`에서 `bg-foreground/5`로 변경
- 검색 결과 항목별 ref를 추가해 키보드 이동 시 선택된 항목이 보이도록 `scrollIntoView` 처리
- 키보드 이동 중 마우스 hover가 선택 인덱스를 덮어쓰지 않도록 `isKeyboardNav` ref 추가
- dialog 내 마우스 이동 시 키보드 네비게이션 상태를 해제하도록 처리
- `app/page.tsx`의 게시물 카드 링크를 `href={post.slug}`에서 `href={`/${post.slug}`}`로 변경

## 범위
### 포함:
- 검색 결과 키보드 선택 하이라이트 색상 수정
- 검색 다이얼로그 닫기 핸들러 안정화
- 검색 다이얼로그 외부 클릭 리스너 의존성 정리
- ESC 키로 검색 다이얼로그 닫기 처리
- 키보드 네비게이션 시 선택된 검색 결과 자동 스크롤 처리
- 키보드 이동과 마우스 hover 간 선택 상태 충돌 방지
- 홈 게시물 카드 링크 절대 경로화
### 제외:
- 검색 데이터 구조 변경
- 검색 인덱스 지연 로드 전환
- 홈 카드 컴포넌트 분리
- 게시물 데이터 계층 리팩토링
- 검색 UI 디자인 전면 변경

## 스크린샷 / 미리 보기