### PR TITLE
[Fix/#36] OG 개선

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -31,12 +31,12 @@ export async function generateMetadata({
 
   return {
     title: post.title,
-    description: post.content.slice(0, 160),
+    description: post.content.trim().slice(0, 160),
     openGraph: {
       type: "website",
       url: `https://blog.d3h1.com/${slug}`,
       title: post.title,
-      description: post.content.slice(0, 160),
+      description: post.content.trim().slice(0, 160),
       siteName: "d3h1 Blog",
       images: [{
         url: post.teaser,
@@ -46,7 +46,7 @@ export async function generateMetadata({
       card: "summary_large_image",
       site: `https://blog.d3h1.com/${slug}`,
       title: post.title,
-      description: post.content.slice(0, 160),
+      description: post.content.trim().slice(0, 160),
       images: [{
         url: post.teaser,
       }],

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -34,7 +34,7 @@ export async function generateMetadata({
     description: post.content.slice(0, 160),
     openGraph: {
       type: "website",
-      url: "https://blog.d3h1.com",
+      url: `https://blog.d3h1.com/${slug}`,
       title: post.title,
       description: post.content.slice(0, 160),
       siteName: "d3h1 Blog",
@@ -44,7 +44,7 @@ export async function generateMetadata({
     },
     twitter: {
       card: "summary_large_image",
-      site: "https://blog.d3h1.com",
+      site: `https://blog.d3h1.com/${slug}`,
       title: post.title,
       description: post.content.slice(0, 160),
       images: [{


### PR DESCRIPTION
## 연관 Issue
- Closes #36

## 요약
글 상세 페이지의 메타데이터에서 모든 게시물이 동일한 사이트 루트 URL을 사용하던 문제를 수정했습니다.

게시물별 Open Graph URL과 Twitter metadata URL이 현재 글의 slug를 포함하도록 변경했고, metadata description 생성 시 본문 앞뒤 공백을 제거한 뒤 160자로 자르도록 정리했습니다.

## 작업 내용
- `app/[slug]/page.tsx`의 `generateMetadata`에서 `openGraph.url`을 `https://blog.d3h1.com/${slug}`로 변경
- `twitter.site` 값을 `https://blog.d3h1.com/${slug}`로 변경
- 기본 `description`을 `post.content.trim().slice(0, 160)`으로 생성하도록 변경
- Open Graph `description`을 `post.content.trim().slice(0, 160)`으로 생성하도록 변경
- Twitter `description`을 `post.content.trim().slice(0, 160)`으로 생성하도록 변경

## 범위
### 포함:
- 글 상세 페이지 metadata 수정
- 게시물별 Open Graph URL 적용
- 게시물별 Twitter metadata URL 적용
- metadata description 생성 시 앞뒤 공백 제거
### 제외:
- 사이트 URL config 단일화
- metadata description을 excerpt 기반으로 전환
- 검색 데이터 구조 변경
- 게시물 데이터 계층 리팩토링
- Open Graph 이미지 구조 변경
- Twitter card 타입 변경

## 스크린샷 / 미리 보기