### PR TITLE
[Fix/#39] 날짜 포맷 로직 개선

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Search from "@/components/Search";
 import Footer from "@/components/Footer";
 import Comments from "@/components/Comments";
 import AllPosts from "@/utils/allpost";
+import { formatDate } from "@/utils/date";
 
 export async function generateStaticParams() {
   const allPosts = await AllPosts();
@@ -52,13 +53,6 @@ export async function generateMetadata({
       }],
     },
   };
-}
-
-function formatDate(date: Date): string {
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, "0");
-  const dd = String(date.getDate()).padStart(2, "0");
-  return `${yyyy}년 ${mm}월 ${dd}일`;
 }
 
 export default async function Post({
@@ -122,7 +116,7 @@ export default async function Post({
                 김 도훈
               </p>
               <time className="text-xs lg:text-sm text-gray-500 dark:text-gray-400 break-keep" dateTime={post.date}>
-                {formatDate(new Date(post.date))}
+                {formatDate(post.date)}
               </time>
               <p className="text-xs lg:text-sm text-gray-500 dark:text-gray-400 break-keep">
                 {post.category}

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -1,0 +1,17 @@
+export function formatDate(rawDate: string): string {
+  const date = new Date(rawDate);
+  if (Number.isNaN(date.getTime())) {
+    return rawDate;
+  }
+
+  const [yyyy, mm, dd] = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Asia/Seoul",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  })
+    .format(date)
+    .split("-");
+
+  return `${yyyy}년 ${mm}월 ${dd}일`;
+}


### PR DESCRIPTION
## 연관 Issue
- Closes #39

## 요약
글 상세 페이지의 날짜 포맷 로직을 공통 유틸로 분리하고, 잘못된 날짜 입력과 서버 타임존 차이에 더 안전하게 동작하도록 개선했습니다.

기존에는 `Date` 객체를 직접 받아 로컬 타임존 기준으로 날짜를 조합했지만, 이제 원본 날짜 문자열을 받아 유효성을 검사한 뒤 KST 기준 `YYYY년 MM월 DD일` 형식으로 변환합니다. 유효하지 않은 날짜는 `NaN년 NaN월 NaN일` 대신 원본 문자열을 그대로 표시합니다.

## 작업 내용
- `utils/date.ts` 파일 추가
- `formatDate(rawDate: string): string` 함수 추가
- `formatDate`에서 `new Date(rawDate)` 결과가 invalid date인지 검사하도록 처리
- invalid date인 경우 원본 문자열을 반환하도록 처리
- `Intl.DateTimeFormat`에 `timeZone: "Asia/Seoul"`을 지정해 KST 기준 날짜 포맷 적용
- `app/[slug]/page.tsx` 내부에 있던 기존 `formatDate(date: Date)` 함수 제거
- 글 상세 페이지에서 `@/utils/date`의 `formatDate`를 import하도록 변경
- `<time>` 표시값 생성 시 `new Date(post.date)` 대신 `formatDate(post.date)`를 호출하도록 변경
- `<time dateTime={post.date}>`에는 기존처럼 원본 날짜 문자열을 유지

## 범위
### 포함:
- 날짜 포맷 유틸 추가
- 글 상세 페이지 날짜 표시 로직 변경
- invalid date fallback 처리
- KST 기준 날짜 포맷 적용
- 기존 inline `formatDate` 함수 제거
### 제외:
- frontmatter date 검증
- 게시물 데이터 계층 리팩토링
- 날짜 표시 디자인 변경
- 다른 페이지의 날짜 표시 로직 변경
- metadata 날짜 처리 변경

## 스크린샷 / 미리 보기