### PR TITLE
[Feat/#40] MDX 플레인텍스트 변환기 추가

### DIFF
--- a/lib/utils/text.ts
+++ b/lib/utils/text.ts
@@ -1,0 +1,26 @@
+export function toPlainText(source: string): string {
+  return source
+    .replace(/```[\s\S]*?```/g, " ")          // 펜스 코드 블록
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")    // 이미지
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")  // 링크 → 텍스트
+    .replace(/`([^`]*)`/g, "$1")              // 인라인 코드
+    .replace(/^#{1,6}\s+/gm, "")              // 헤딩 마커
+    .replace(/^>\s?/gm, "")                   // 인용 마커
+    .replace(/(\*\*|__)(.*?)\1/g, "$2")       // 굵게
+    .replace(/(\*|_)(.*?)\1/g, "$2")          // 기울임
+    .replace(/~~(.*?)~~/g, "$1")              // 취소선
+    .replace(/<[^>]+>/g, " ")                 // HTML/JSX 태그
+    .replace(/^\s*[-*+]\s+/gm, "")            // 리스트 마커
+    .replace(/^\s*\d+\.\s+/gm, "")            // 번호 리스트 마커
+    .replace(/^\s*\|?[\s|:-]+\|?\s*$/gm, " ") // 표 구분선(---, :---: 행)
+    .replace(/\|/g, " ")                      // 표 파이프
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function toExcerpt(plainText: string, maxLength = 200): string {
+  if (plainText.length <= maxLength) {
+    return plainText;
+  }
+  return `${plainText.slice(0, maxLength).trimEnd()}…`;
+}


### PR DESCRIPTION
## 연관 Issue
- Closes #40

## 요약
MDX 본문에서 마크업을 제거해 플레인텍스트로 변환하는 유틸을 추가했습니다.

## 작업 내용
- `lib/utils/text.ts` 파일 추가
- `toPlainText(source: string): string` 함수 추가
- 펜스 코드 블록 제거 처리 추가
- 이미지 문법 제거 처리 추가
- 링크 문법은 URL을 제거하고 텍스트만 남기도록 처리
- 인라인 코드 마커 제거 처리 추가
- 헤딩 마커 제거 처리 추가
- 인용 마커 제거 처리 추가
- 굵게, 기울임, 취소선 마커 제거 처리 추가
- HTML/JSX 태그 제거 처리 추가
- 순서/비순서 리스트 마커 제거 처리 추가
- Markdown 표 구분선과 파이프 문자 제거 처리 추가
- 연속 공백을 하나의 공백으로 정규화하도록 처리
- `toExcerpt(plainText: string, maxLength = 200): string` 함수 추가
- excerpt가 최대 길이를 초과할 경우 잘라낸 뒤 `…`를 붙이도록 처리

## 범위
### 포함:
- MDX/Markdown 마크업 제거 유틸 추가
- 플레인텍스트 기반 excerpt 생성 유틸 추가
- 검색 인덱스와 excerpt 생성을 위한 기반 유틸 추가
### 제외:
- frontmatter 파싱
- 실제 게시물 로딩 로직 변경
- 검색 UI 변경
- 검색 인덱스 생성 라우트 추가
- 홈 카드 excerpt 적용
- 글 메타 description excerpt 적용
- 유닛 테스트 추가

## 스크린샷 / 미리 보기