### PR TITLE
[Refactor/#59] 게시물 meta 검증 및 검색 데이터 지연 로드 전환

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -76,7 +76,7 @@ export default async function Post({
   return (
     <>
       <Header />
-      <Search allPosts={base} />
+      <Search />
       <div className="mx-auto my-24 px-4 max-w-[1325px]
         flex flex-col
         lg:grid grid-cols-[1fr_240px] gap-x-12"

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -32,12 +32,12 @@ export async function generateMetadata({
 
   return {
     title: post.title,
-    description: post.content.trim().slice(0, 160),
+    description: post.excerpt,
     openGraph: {
       type: "website",
       url: `https://blog.d3h1.com/${slug}`,
       title: post.title,
-      description: post.content.trim().slice(0, 160),
+      description: post.excerpt,
       siteName: "d3h1 Blog",
       images: [{
         url: post.teaser.src,
@@ -47,7 +47,7 @@ export async function generateMetadata({
       card: "summary_large_image",
       site: `https://blog.d3h1.com/${slug}`,
       title: post.title,
-      description: post.content.trim().slice(0, 160),
+      description: post.excerpt,
       images: [{
         url: post.teaser.src,
       }],

--- a/app/index/route.ts
+++ b/app/index/route.ts
@@ -1,0 +1,7 @@
+import { allPosts } from "@/lib/utils/post";
+
+export const dynamic = "force-static";
+
+export async function GET() {
+  return Response.json(await allPosts());
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -99,7 +99,7 @@ export default async function Home({
                   <p className="text-xs lg:text-sm
                     line-clamp-2 text-gray-500 dark:text-gray-400"
                   >
-                    {post.content}
+                    {post.excerpt}
                   </p>
                 </Link>
               </article>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,7 +36,7 @@ export default async function Home({
   return (
     <>
       <Header />
-      <Search allPosts={base} />
+      <Search />
       <div className="mx-auto my-24 px-4 max-w-[1325px]
         flex flex-col
         lg:grid grid-cols-[1fr_240px] gap-x-12"

--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -103,7 +103,7 @@ export default function Search({
                       <div className="text-xs lg:text-sm mt-1
                         truncate text-gray-500 dark:text-gray-400"
                       >
-                        {post.content.slice(0, 100)}...
+                        {post.excerpt}
                       </div>
                     </article>
                     <div className="text-xs lg:text-sm px-2 py-1

--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -1,16 +1,50 @@
 "use client";
 
+import { useState, useEffect, useCallback } from "react";
 import Image from "next/image";
 import Icon from "../Icon";
 import Button from "../Button";
 import Post from "@/lib/types/post";
 import useSearchDialog from "@/lib/hooks/search";
+import { useSearch } from "@/lib/contexts/SearchContext";
 
-export default function Search({
-  allPosts
-}: {
-  allPosts: Post[]
-}) {
+let searchDocsCache: Post[] | null = null;
+
+type LoadState = "idle" | "loaded" | "error";
+
+export default function Search() {
+  const { isOpen } = useSearch();
+  const [docs, setDocs] = useState<Post[]>(searchDocsCache ?? []);
+  const [loadState, setLoadState] = useState<LoadState>(searchDocsCache ? "loaded" : "idle");
+
+  const loadDocs = useCallback(async () => {
+    if (searchDocsCache) {
+      setDocs(searchDocsCache);
+      setLoadState("loaded");
+      return;
+    }
+
+    try {
+      const res = await fetch("/index");
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const data: Post[] = await res.json();
+      searchDocsCache = data;
+      setDocs(data);
+      setLoadState("loaded");
+    } catch {
+      setLoadState("error");
+    }
+  }, []);
+
+  // 다이얼로그가 처음 열릴 때 검색 인덱스 지연 로드
+  useEffect(() => {
+    if (isOpen && loadState === "idle") {
+      loadDocs();
+    }
+  }, [isOpen, loadState, loadDocs]);
+
   const {
     dialogRef,
     inputRef,
@@ -25,7 +59,7 @@ export default function Search({
     handleMouseEnterItem,
     handleMouseMove,
     navigateToPost,
-  } = useSearchDialog(allPosts);
+  } = useSearchDialog(docs);
 
   // dialog 닫힐 때 처리
   const handleCancel = (e: React.FormEvent<HTMLDialogElement>) => {
@@ -74,7 +108,18 @@ export default function Search({
           </kbd>
         </div>
 
-        {searchKeyword && (
+        {loadState === "error" && (
+          <div className="flex flex-col items-center gap-3 px-4 py-6">
+            <p className="text-xs lg:text-sm text-center">
+              문제가 발생했습니다
+            </p>
+            <Button size="small" onClick={loadDocs}>
+              다시 시도
+            </Button>
+          </div>
+        )}
+
+        {loadState === "loaded" && searchKeyword && (
           <div className="max-h-50 overflow-auto">
             {displayedPosts.length > 0 ? (
               <>

--- a/lib/types/post.ts
+++ b/lib/types/post.ts
@@ -10,4 +10,5 @@ export interface PostMeta {
 export default interface Post extends PostMeta {
   slug: string;
   content: string;
+  excerpt: string;
 }

--- a/lib/utils/meta.ts
+++ b/lib/utils/meta.ts
@@ -12,8 +12,8 @@ export function validatePostMeta(slug: string, meta: unknown): string[] {
     errors.push(`${post} meta.title은 반드시 문자열이여야 하며 비어 있을 수 없습니다.`);
   }
 
-  if (typeof m.description !== "string" || m.description.trim() === "") {
-    errors.push(`${post} meta.description은 반드시 문자열이여야 하며 비어 있을 수 없습니다.`);
+  if (typeof m.category !== "string" || m.category.trim() === "") {
+    errors.push(`${post} meta.category은 반드시 문자열이여야 하며 비어 있을 수 없습니다.`);
   }
 
   if (typeof m.date !== "string" || isNaN(Date.parse(m.date))) {

--- a/lib/utils/meta.ts
+++ b/lib/utils/meta.ts
@@ -9,15 +9,15 @@ export function validatePostMeta(slug: string, meta: unknown): string[] {
   const errors: string[] = [];
 
   if (typeof m.title !== "string" || m.title.trim() === "") {
-    errors.push(`${post} meta.title must be a string and cannot be empty`);
+    errors.push(`${post} meta.title은 반드시 문자열이여야 하며 비어 있을 수 없습니다.`);
   }
 
   if (typeof m.description !== "string" || m.description.trim() === "") {
-    errors.push(`${post} meta.description must be a string and cannot be empty`);
+    errors.push(`${post} meta.description은 반드시 문자열이여야 하며 비어 있을 수 없습니다.`);
   }
 
   if (typeof m.date !== "string" || isNaN(Date.parse(m.date))) {
-    errors.push(`${post} meta.date must be a valid date string`);
+    errors.push(`${post} meta.date은 반드시 유효한 날짜 문자열이어야 합니다.`);
   }
 
   const teaser = m.teaser;
@@ -26,7 +26,7 @@ export function validatePostMeta(slug: string, meta: unknown): string[] {
     typeof teaser !== "object" ||
     typeof (teaser as { src?: unknown }).src !== "string"
   ) {
-    errors.push(`${post}: teaser — import된 이미지(StaticImageData)여야 합니다`);
+    errors.push(`${post} meta.teaser은 반드시 import된 이미지(StaticImageData)여야 합니다`);
   }
 
   return errors;

--- a/lib/utils/meta.ts
+++ b/lib/utils/meta.ts
@@ -1,0 +1,33 @@
+export function validatePostMeta(slug: string, meta: unknown): string[] {
+  const post = `posts/${slug}/post.mdx`;
+
+  if (typeof meta !== "object" || meta === null) {
+    return [`${post} does not export a meta object`];
+  }
+
+  const m = meta as Record<string, unknown>;
+  const errors: string[] = [];
+
+  if (typeof m.title !== "string" || m.title.trim() === "") {
+    errors.push(`${post} meta.title must be a string and cannot be empty`);
+  }
+
+  if (typeof m.description !== "string" || m.description.trim() === "") {
+    errors.push(`${post} meta.description must be a string and cannot be empty`);
+  }
+
+  if (typeof m.date !== "string" || isNaN(Date.parse(m.date))) {
+    errors.push(`${post} meta.date must be a valid date string`);
+  }
+
+  const teaser = m.teaser;
+  if (
+    teaser === null ||
+    typeof teaser !== "object" ||
+    typeof (teaser as { src?: unknown }).src !== "string"
+  ) {
+    errors.push(`${post}: teaser — import된 이미지(StaticImageData)여야 합니다`);
+  }
+
+  return errors;
+}

--- a/lib/utils/post.ts
+++ b/lib/utils/post.ts
@@ -3,6 +3,7 @@ import { readdir, readFile } from "fs/promises";
 import path from "path";
 import Post from "@/lib/types/post";
 import { toPlainText } from "@/lib/utils/text";
+import { validatePostMeta } from "@/lib/utils/meta";
 
 export const allPosts = cache(async function (): Promise<Post[]> {
   // `.mdx` 파일 저장 경로 선언
@@ -12,29 +13,41 @@ export const allPosts = cache(async function (): Promise<Post[]> {
   const dir = await readdir(postPath, { withFileTypes: true });
   const files = dir.filter((file) => file.isDirectory());
 
+  const errors: string[] = [];
+  const posts: Post[] = [];
+
   // 각 게시물의 메타데이터 및 경로 정보 반환
-  const posts: Post[] = await Promise.all(
+  await Promise.all(
     files.map(async (file) => {
       // 슬러그 생성
       const slug = file.name;
 
       // 메타데이터는 MDX 모듈의 `meta` export에서 추출
       const { meta } = await import(`@/posts/${slug}/post.mdx`);
-      if (!meta) {
-        throw new Error(`No meta export found in post: ${slug}`);
+
+      const metaErrors = validatePostMeta(slug, meta);
+      if (metaErrors.length > 0) {
+        errors.push(...metaErrors);
+        return;
       }
 
       // 글 내용 추출 (상단의 import/export 선언 제거)
       const raw = await readFile(path.join(postPath, slug, "post.mdx"), "utf-8");
       const content = toPlainText(raw);
 
-      return {
+      posts.push({
         slug,
         content,
         ...meta,
-      } as Post;
+      });
     })
   );
+
+  if (errors.length > 0) {
+    throw new Error(
+      `게시글 메타데이터 검증 실패 (${errors.length}건):\n${errors.sort().join("\n")}`
+    );
+  }
 
   posts.sort((a, b) => +new Date(b.date) - +new Date(a.date));
 

--- a/lib/utils/post.ts
+++ b/lib/utils/post.ts
@@ -2,7 +2,7 @@ import { cache } from "react";
 import { readdir, readFile } from "fs/promises";
 import path from "path";
 import Post from "@/lib/types/post";
-import { toPlainText } from "@/lib/utils/text";
+import { toExcerpt, toPlainText } from "@/lib/utils/text";
 import { validatePostMeta } from "@/lib/utils/meta";
 
 export const allPosts = cache(async function (): Promise<Post[]> {
@@ -34,10 +34,12 @@ export const allPosts = cache(async function (): Promise<Post[]> {
       // 글 내용 추출 (상단의 import/export 선언 제거)
       const raw = await readFile(path.join(postPath, slug, "post.mdx"), "utf-8");
       const content = toPlainText(raw);
+      const excerpt = toExcerpt(content);
 
       posts.push({
         slug,
         content,
+        excerpt,
         ...meta,
       });
     })


### PR DESCRIPTION
## 연관 Issue
- Closes #59

## 요약
게시물 MDX의 `meta` export를 검증하는 유틸을 추가하고, 게시물 로더에서 meta 오류를 한 번에 모아 보고하도록 변경했습니다.

또한 `Post`에 `excerpt` 필드를 추가해 홈 카드, 글 메타데이터, 검색 결과 미리보기에 사용하도록 변경했고, Search 컴포넌트가 게시물 데이터를 props로 받지 않고 검색 다이얼로그가 열릴 때 `/index`에서 지연 로드하도록 개선했습니다.

## 작업 내용
- `lib/utils/meta.ts` 파일 추가
- `validatePostMeta(slug, meta): string[]` 함수 추가
- `meta`가 객체가 아닌 경우 오류를 반환하도록 처리
- `meta.title` 문자열 검증 추가
- `meta.category` 문자열 검증 추가
- `meta.date` 유효한 날짜 문자열 검증 추가
- `meta.teaser`가 import된 이미지 객체인지 검증 추가
- `allPosts()`에서 게시물별 meta 검증 오류를 수집하도록 변경
- meta 검증 오류가 있을 경우 `게시글 메타데이터 검증 실패` 메시지로 한 번에 throw하도록 처리
- `Post` 인터페이스에 `excerpt` 필드 추가
- `allPosts()`에서 `toExcerpt(content)`로 excerpt를 생성하도록 변경
- 홈 카드 미리보기에서 `post.content` 대신 `post.excerpt`를 사용하도록 변경
- 글 상세 페이지 metadata description에서 `post.excerpt`를 사용하도록 변경
- 검색 결과 미리보기에서 `post.excerpt`를 사용하도록 변경
- `app/index/route.ts` 파일 추가
- `/index` route에서 `allPosts()` 결과를 JSON으로 반환하도록 처리
- `/index` route를 정적 생성하도록 설정
- `Search` 컴포넌트의 `allPosts` props 제거
- 검색 다이얼로그가 처음 열릴 때 `/index`를 fetch하도록 변경
- 검색 인덱스를 모듈 수준 변수로 캐시하도록 처리
- 검색 인덱스 로드 실패 시 다시 시도 UI 추가
- `app/page.tsx`, `app/[slug]/page.tsx`에서 `<Search allPosts={...} />`를 `<Search />`로 변경

## 범위
### 포함:
- 게시물 meta 검증 유틸 추가
- 게시물 로더의 meta 검증 및 오류 일괄 보고
- 게시물 excerpt 필드 추가
- 홈 카드, 글 metadata, 검색 결과 미리보기의 excerpt 적용
- `/index` 기반 검색 인덱스 route 추가
- Search 컴포넌트의 게시물 데이터 props 제거
- 검색 다이얼로그 최초 열림 시 검색 데이터 지연 로드
- 검색 데이터 모듈 수준 캐싱
- 검색 인덱스 fetch 실패 시 재시도 UI 추가
### 제외:
- 게시물 원본 `posts/*/post.mdx` 수정
- 사이트 설정 단일화
- 카테고리 설정 단일화
- Button/Icon/PostCard 컴포넌트 정리
- 404/error 페이지 추가
- Footer/Comments 설정 분리
- 검색 UI 디자인 변경
- 별도 유닛 테스트 추가

## 스크린샷 / 미리 보기
<img width="1033" height="396" alt="image" src="https://github.com/user-attachments/assets/44a241b2-60c1-41f9-bb4b-ad217ceb864f" />
<img width="650" height="324" alt="image" src="https://github.com/user-attachments/assets/0e4d0d9a-41bd-4fb8-9f57-a469eb7bb88a" />
<img width="1011" height="623" alt="image" src="https://github.com/user-attachments/assets/b6c5de9d-797a-4415-aea1-639e508f348d" />