### PR TITLE
[Refactor/#60] 사이트 설정과 카테고리 설정 단일화

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -6,6 +6,7 @@ import Footer from "@/components/Footer";
 import Comments from "@/components/Comments";
 import { allPosts } from "@/lib/utils/post";
 import { formatDate } from "@/lib/utils/date";
+import { siteConfig } from "@/lib/config/site";
 
 export async function generateStaticParams() {
   const base = await allPosts();
@@ -35,17 +36,17 @@ export async function generateMetadata({
     description: post.excerpt,
     openGraph: {
       type: "website",
-      url: `https://blog.d3h1.com/${slug}`,
+      url: `${siteConfig.url}/${slug}`,
       title: post.title,
       description: post.excerpt,
-      siteName: "d3h1 Blog",
+      siteName: siteConfig.name,
       images: [{
         url: post.teaser.src,
       }],
     },
     twitter: {
       card: "summary_large_image",
-      site: `https://blog.d3h1.com/${slug}`,
+      site: `${siteConfig.url}/${slug}`,
       title: post.title,
       description: post.excerpt,
       images: [{

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -112,7 +112,7 @@ export default async function Post({
                   rounded-full object-cover"
               />
               <p className="text-sm lg:text-base font-bold">
-                김 도훈
+                {siteConfig.author.firstName} {siteConfig.author.lastName}
               </p>
               <time className="text-xs lg:text-sm text-gray-500 dark:text-gray-400 break-keep" dateTime={post.date}>
                 {formatDate(post.date)}

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -112,7 +112,7 @@ export default async function Post({
                   rounded-full object-cover"
               />
               <p className="text-sm lg:text-base font-bold">
-                {siteConfig.author.firstName} {siteConfig.author.lastName}
+                {siteConfig.author.lastName} {siteConfig.author.firstName}
               </p>
               <time className="text-xs lg:text-sm text-gray-500 dark:text-gray-400 break-keep" dateTime={post.date}>
                 {formatDate(post.date)}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import { SearchProvider } from "@/lib/contexts/SearchContext";
+import { siteConfig } from "@/lib/config/site";
 import "./globals.css";
 
 const pretendard = localFont({
@@ -12,32 +13,32 @@ const pretendard = localFont({
 
 export const metadata: Metadata = {
   title: {
-    template: "%s | d3h1 Blog",
-    default: "d3h1 Blog",
+    template: `%s | ${siteConfig.name}`,
+    default: siteConfig.name,
   },
-  description: "새로운 것을 즐기고, 변화를 만들고",
-  metadataBase: new URL("https://blog.d3h1.com"),
+  description: siteConfig.description,
+  metadataBase: new URL(siteConfig.url),
   openGraph: {
     type: "website",
-    url: "https://blog.d3h1.com",
+    url: siteConfig.url,
     title: {
-      template: "%s | d3h1 Blog",
-      default: "d3h1 Blog",
+      template: `%s | ${siteConfig.name}`,
+      default: siteConfig.name,
     },
-    description: "새로운 것을 즐기고, 변화를 만들고",
-    siteName: "d3h1 Blog",
+    description: siteConfig.description,
+    siteName: siteConfig.name,
     images: [{
       url: "/opengraph.png",
     }],
   },
   twitter: {
     card: "summary_large_image",
-    site: "https://blog.d3h1.com",
+    site: siteConfig.url,
     title: {
-      template: "%s | d3h1 Blog",
-      default: "d3h1 Blog",
+      template: `%s | ${siteConfig.name}`,
+      default: siteConfig.name,
     },
-    description: "새로운 것을 즐기고, 변화를 만들고",
+    description: siteConfig.description,
     images: [{
       url: "/opengraph.png",
     }],

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,17 +5,8 @@ import Search from "@/components/Search";
 import Footer from "@/components/Footer";
 import Button from "@/components/Button";
 import { allPosts } from "@/lib/utils/post";
+import { categories, ALL_CATEGORY_LABEL } from "@/lib/config/categories";
 import Post from "@/lib/types/post";
-
-const categories: {
-  title: string;
-  params: string;
-}[] = [
-  { title: "전체", params: "" },
-  { title: "개발", params: "development" },
-  { title: "후기", params: "review" },
-  { title: "잡담", params: "talk" },
-]
 
 export default async function Home({
   searchParams
@@ -25,11 +16,18 @@ export default async function Home({
 }) {
   const { category } = await searchParams;
 
-  const selectedCategory = categories.find((c) => c.params === category || c.title === category)?.title || "전체";
+  const filterOptions = [
+    { slug: "", label: ALL_CATEGORY_LABEL },
+    ...categories,
+  ];
+
+  const selectedCategory =
+    filterOptions.find((c) => c.slug === category || c.label === category)?.label
+      ?? ALL_CATEGORY_LABEL;
 
   const base = await allPosts();
   const posts = base.filter((post) => {
-    if (!selectedCategory || selectedCategory === "전체") return true;
+    if (selectedCategory === ALL_CATEGORY_LABEL) return true;
     return post.category === selectedCategory;
   });
 
@@ -48,17 +46,16 @@ export default async function Home({
           <div className="w-full select-none
             flex flex-wrap gap-2"
           >
-            {categories.map((category) => (
+            {filterOptions.map((option) => (
               <Link
-                key={category.params}
-                href={category.params ? `/?category=${category.params}` : "/"}
+                key={option.slug}
+                href={option.slug ? `/?category=${option.slug}` : "/"}
               >
                 <Button
-                  key={category.params}
                   size="medium"
-                  variant={selectedCategory === category.title ? "filled" : "linear"}
+                  variant={selectedCategory === option.label ? "filled" : "linear"}
                 >
-                  {category.title}
+                  {option.label}
                 </Button>
               </Link>
             ))}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,8 +1,9 @@
-import type { MetadataRoute } from 'next';
+import type { MetadataRoute } from "next";
+import { siteConfig } from "@/lib/config/site";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: { userAgent: '*', allow: '/' },
-    sitemap: "https://blog.d3h1.com/sitemap.xml",
+    rules: { userAgent: "*", allow: "/" },
+    sitemap: `${siteConfig.url}/sitemap.xml`,
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,11 +1,12 @@
 import type { MetadataRoute } from "next";
 import { allPosts } from "@/lib/utils/post";
+import { siteConfig } from "@/lib/config/site";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const posts = await allPosts();
 
   const postRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
-    url: `https://blog.d3h1.com/${post.slug}`,
+    url: `${siteConfig.url}/${post.slug}`,
     lastModified: new Date(post.date),
     changeFrequency: "weekly",
     priority: 0.8,
@@ -13,7 +14,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   return [
     {
-      url: "https://blog.d3h1.com",
+      url: siteConfig.url,
       lastModified: new Date(),
       changeFrequency: "daily",
       priority: 1.0,

--- a/components/Comments/index.tsx
+++ b/components/Comments/index.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import Giscus from '@giscus/react';
+import Giscus from "@giscus/react";
+import { siteConfig } from "@/lib/config/site";
 
 export default function Comments() {
   return (
     <Giscus
       id="comments"
-      repo="dohun0310/d3h1-Blog-comment"
-      repoId="R_kgDOJ-0RuA"
-      category="General"
-      categoryId="DIC_kwDOJ-0RuM4CYGS5"
+      repo={siteConfig.giscus.repo}
+      repoId={siteConfig.giscus.repoId}
+      category={siteConfig.giscus.category}
+      categoryId={siteConfig.giscus.categoryId}
       mapping="pathname"
       reactionsEnabled="1"
       emitMetadata="0"

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -1,11 +1,5 @@
 import Icon from "../Icon";
-
-const socialLinks = [
-  { name: "instagram", href: "https://www.instagram.com/dohun0310/" },
-  { name: "facebook", href: "https://www.facebook.com/dohun0310/" },
-  { name: "x", href: "https://x.com/dohun0310/" },
-  { name: "github", href: "https://github.com/dohun0310/" },
-] as const;
+import { siteConfig } from "@/lib/config/site";
 
 const socialLinkClass = `inline-flex justify-center items-center p-2
   gap-1.5 rounded-full cursor-pointer select-none
@@ -20,7 +14,7 @@ export default function Footer() {
       static lg:fixed lg:right-[calc((100%-1325px)/2+16px)]"
     >
       <div className="w-full flex items-center justify-center gap-4 lg:justify-between">
-        {socialLinks.map((link) => (
+        {siteConfig.socials.map((link) => (
           <a
             key={link.name}
             href={link.href}
@@ -44,7 +38,7 @@ export default function Footer() {
         [@media(min-width:1325px)_and_(max-height:317px)]:aspect-32/5"
       />
       <p className="text-xs lg:text-sm text-gray-500 dark:text-gray-400">
-        © 2023-2026 d3h1. 모든 권리 보유.
+        {siteConfig.copyright}
       </p>
     </footer>
   )

--- a/lib/config/categories.ts
+++ b/lib/config/categories.ts
@@ -1,0 +1,12 @@
+export interface Category {
+  slug: string;
+  label: string;
+}
+
+export const ALL_CATEGORY_LABEL = "전체";
+
+export const categories: Category[] = [
+  { slug: "development", label: "개발" },
+  { slug: "review", label: "후기" },
+  { slug: "talk", label: "잡담" },
+];

--- a/lib/config/site.ts
+++ b/lib/config/site.ts
@@ -1,0 +1,47 @@
+import type { IconName } from "@/lib/types/icon";
+
+export interface SocialLink {
+  name: IconName;
+  href: string;
+}
+
+export interface SiteConfig {
+  url: string;
+  name: string;
+  description: string;
+  author: {
+    firstName: string;
+    lastName: string;
+  };
+  copyright: string;
+  socials: SocialLink[];
+  giscus: {
+    repo: `${string}/${string}`;
+    repoId: string;
+    category: string;
+    categoryId: string;
+  };
+}
+
+export const siteConfig: SiteConfig = {
+  url: "https://blog.d3h1.com",
+  name: "d3h1 Blog",
+  description: "새로운 것을 즐기고, 변화를 만들고",
+  author: {
+    firstName: "도훈",
+    lastName: "김",
+  },
+  copyright: "© 2023-2026 d3h1. 모든 권리 보유.",
+  socials: [
+    { name: "instagram", href: "https://www.instagram.com/dohun0310/" },
+    { name: "facebook", href: "https://www.facebook.com/dohun0310/" },
+    { name: "x", href: "https://x.com/dohun0310/" },
+    { name: "github", href: "https://github.com/dohun0310/" },
+  ],
+  giscus: {
+    repo: "dohun0310/d3h1-Blog-comment",
+    repoId: "R_kgDOJ-0RuA",
+    category: "General",
+    categoryId: "DIC_kwDOJ-0RuM4CYGS5",
+  },
+};

--- a/lib/config/site.ts
+++ b/lib/config/site.ts
@@ -23,8 +23,12 @@ export interface SiteConfig {
   };
 }
 
+const url = process.env.VERCEL_PROJECT_PRODUCTION_URL
+  ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+  : 'http://localhost:3000';
+
 export const siteConfig: SiteConfig = {
-  url: "https://blog.d3h1.com",
+  url: url,
   name: "d3h1 Blog",
   description: "새로운 것을 즐기고, 변화를 만들고",
   author: {

--- a/lib/config/site.ts
+++ b/lib/config/site.ts
@@ -35,7 +35,7 @@ export const siteConfig: SiteConfig = {
     firstName: "도훈",
     lastName: "김",
   },
-  copyright: "© 2023-2026 d3h1. 모든 권리 보유.",
+  copyright: `© 2023-${new Date().getFullYear()} d3h1. 모든 권리 보유.`,
   socials: [
     { name: "instagram", href: "https://www.instagram.com/dohun0310/" },
     { name: "facebook", href: "https://www.facebook.com/dohun0310/" },

--- a/lib/utils/meta.ts
+++ b/lib/utils/meta.ts
@@ -1,3 +1,5 @@
+import { categories } from "@/lib/config/categories";
+
 export function validatePostMeta(slug: string, meta: unknown): string[] {
   const post = `posts/${slug}/post.mdx`;
 
@@ -12,8 +14,8 @@ export function validatePostMeta(slug: string, meta: unknown): string[] {
     errors.push(`${post} meta.title은 반드시 문자열이여야 하며 비어 있을 수 없습니다.`);
   }
 
-  if (typeof m.category !== "string" || m.category.trim() === "") {
-    errors.push(`${post} meta.category은 반드시 문자열이여야 하며 비어 있을 수 없습니다.`);
+  if (typeof m.category !== "string" || !categories.some((c) => c.slug === m.category)) {
+    errors.push(`${post} meta.category은 ${categories.map((c) => c.slug).join(", ")} 중 하나여야 하며 비어 있을 수 없습니다.`);
   }
 
   if (typeof m.date !== "string" || isNaN(Date.parse(m.date))) {

--- a/lib/utils/meta.ts
+++ b/lib/utils/meta.ts
@@ -14,8 +14,8 @@ export function validatePostMeta(slug: string, meta: unknown): string[] {
     errors.push(`${post} meta.title은 반드시 문자열이여야 하며 비어 있을 수 없습니다.`);
   }
 
-  if (typeof m.category !== "string" || !categories.some((c) => c.slug === m.category)) {
-    errors.push(`${post} meta.category은 ${categories.map((c) => c.slug).join(", ")} 중 하나여야 하며 비어 있을 수 없습니다.`);
+  if (typeof m.category !== "string" || !categories.some((c) => c.label === m.category)) {
+    errors.push(`${post} meta.category은 ${categories.map((c) => c.label).join(", ")} 중 하나여야 하며 비어 있을 수 없습니다.`);
   }
 
   if (typeof m.date !== "string" || isNaN(Date.parse(m.date))) {


### PR DESCRIPTION
## 연관 Issue
- Closes #60

## 요약
사이트 URL, 메타데이터, 작성자, 소셜 링크, Giscus 설정, 카테고리 목록을 `lib/config/` 하위 설정 파일로 분리했습니다.

홈 카테고리 필터와 게시물 meta category 검증도 공통 카테고리 설정을 사용하도록 변경했고, layout, sitemap, robots, Footer, Comments에서 하드코딩된 설정값을 `siteConfig` 기반으로 정리했습니다.

## 작업 내용
- `lib/config/categories.ts` 파일 추가
- `Category` 인터페이스 추가
- `ALL_CATEGORY_LABEL` 상수 추가
- `categories` 배열에 개발, 후기, 잡담 카테고리 정의
- `lib/config/site.ts` 파일 추가
- `SiteConfig` 인터페이스 추가
- `siteConfig.url`, `name`, `description` 설정 추가
- `siteConfig.author` 설정 추가
- `siteConfig.copyright` 설정 추가
- `siteConfig.socials` 설정 추가
- `siteConfig.giscus` 설정 추가
- `siteConfig.url`이 `VERCEL_PROJECT_PRODUCTION_URL` 환경 변수를 우선 사용하도록 처리
- copyright 문구가 현재 연도를 반영하도록 변경
- `validatePostMeta`의 category 검증이 `categories` 설정을 사용하도록 변경
- 등록되지 않은 category가 들어오면 허용된 카테고리 목록을 포함해 오류를 반환하도록 변경
- `app/page.tsx`의 카테고리 하드코딩 배열 제거
- 홈 카테고리 필터가 `categories`, `ALL_CATEGORY_LABEL`을 사용하도록 변경
- `category` query가 slug 또는 label 기준으로 기존과 동일하게 동작하도록 처리
- `app/layout.tsx`의 title, description, metadataBase, Open Graph, Twitter metadata를 `siteConfig` 기반으로 변경
- `app/[slug]/page.tsx`의 Open Graph URL과 siteName을 `siteConfig` 기반으로 변경
- 글 상세 페이지의 작성자 표시를 `siteConfig.author` 기반으로 변경
- `app/sitemap.ts`의 URL 생성을 `siteConfig.url` 기반으로 변경
- `app/robots.ts`의 sitemap URL을 `siteConfig.url` 기반으로 변경
- `components/Footer/index.tsx`의 소셜 링크 로컬 상수 제거
- Footer 소셜 링크와 저작권 문구를 `siteConfig` 기반으로 변경
- `components/Comments/index.tsx`의 Giscus 설정을 `siteConfig.giscus` 기반으로 변경

## 범위
### 포함:
- 사이트 설정 파일 추가
- 카테고리 설정 파일 추가
- 홈 카테고리 필터 설정 소스 변경
- 게시물 meta category 검증 강화
- layout metadata 설정 단일화
- 글 상세 metadata와 작성자 표시 설정 단일화
- sitemap URL 설정 단일화
- robots sitemap URL 설정 단일화
- Footer 소셜 링크와 저작권 설정 단일화
- Comments Giscus 설정 단일화
- Vercel 배포 환경 기반 사이트 URL 처리
### 제외:
- 게시물 검색 지연 로드 구조 변경
- Search 컴포넌트 내부 로직 변경
- Button/Icon/PostCard 컴포넌트 정리
- 404/error 페이지 추가
- 게시물 원본 `posts/*/post.mdx` 수정
- 디자인/레이아웃 변경
- 댓글 시스템 변경
- 소셜 링크 구성 변경
- 카테고리 체계 변경

## 스크린샷 / 미리 보기
<img width="271" height="96" alt="image" src="https://github.com/user-attachments/assets/6f8c208c-ad59-44ec-bda7-48c8f5bf7d55" />
<img width="154" height="237" alt="image" src="https://github.com/user-attachments/assets/dc1d0d42-c95d-4a25-b289-b162223739bc" />
<img width="1045" height="409" alt="image" src="https://github.com/user-attachments/assets/270fd0ef-b645-40d3-b76a-3027e9ff3e37" />