### PR TITLE
[Refactor/#69] 레이아웃 구성 요소를 통합하여 코드 구조 개선

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -1,8 +1,5 @@
 import { notFound } from "next/navigation";
 import Image from "next/image";
-import Header from "@/components/Header";
-import Search from "@/components/Search";
-import Footer from "@/components/Footer";
 import Comments from "@/components/Comments";
 import { allPosts } from "@/lib/utils/post";
 import { formatDate } from "@/lib/utils/date";
@@ -75,68 +72,58 @@ export default async function Post({
   const PostContent = (await import(`@/posts/${post.slug}/post.mdx`)).default;
 
   return (
-    <>
-      <Header />
-      <Search />
-      <div className="mx-auto my-24 px-4 max-w-[1325px]
-        flex flex-col
-        lg:grid grid-cols-[1fr_240px] gap-x-12"
+    <article className="mx-auto w-full max-w-247.5
+      flex flex-col gap-8 break-keep"
+    >
+      <h1 className="text-2xl font-bold lg:text-3xl">
+        {post.title}
+      </h1>
+      <Image
+        src={post.teaser}
+        alt={`Teaser image for ${post.title}`}
+        sizes="(max-width: 684px) 100vw,
+              70vw"
+        className="w-full h-auto"
+        fetchPriority="high"
+        priority
+      />
+      <div className="flex flex-col-reverse gap-8
+        lg:grid grid-cols-[100px_1fr] gap-x-7"
       >
-        <article className="mx-auto w-full max-w-247.5
-          flex flex-col gap-8 break-keep"
+        <div className="flex items-center gap-3
+          lg:flex-col lg:items-start lg:gap-2"
         >
-          <h1 className="text-2xl font-bold lg:text-3xl">
-            {post.title}
-          </h1>
           <Image
-            src={post.teaser}
-            alt={`Teaser image for ${post.title}`}
-            sizes="(max-width: 684px) 100vw,
-                  70vw"
-            className="w-full h-auto"
-            fetchPriority="high"
-            priority
+            src="/profile.png"
+            alt="d3h1 Profile Image"
+            width={128}
+            height={128}
+            className="w-12 h-12 lg:w-25 lg:h-25
+              rounded-full object-cover"
           />
-          <div className="flex flex-col-reverse gap-8
-            lg:grid grid-cols-[100px_1fr] gap-x-7"
-          >
-            <div className="flex items-center gap-3
-              lg:flex-col lg:items-start lg:gap-2"
-            >
-              <Image
-                src="/profile.png"
-                alt="d3h1 Profile Image"
-                width={128}
-                height={128}
-                className="w-12 h-12 lg:w-25 lg:h-25
-                  rounded-full object-cover"
-              />
-              <p className="text-sm lg:text-base font-bold">
-                {siteConfig.author.lastName} {siteConfig.author.firstName}
-              </p>
-              <time className="text-xs lg:text-sm text-gray-500 dark:text-gray-400 break-keep" dateTime={post.date}>
-                {formatDate(post.date)}
-              </time>
-              <p className="text-xs lg:text-sm text-gray-500 dark:text-gray-400 break-keep">
-                {post.category}
-              </p>
-            </div>
-            <div className="w-full max-w-full lg:max-w-217.5
-              [&_a:hover]:underline [&_pre]:py-5 [&_pre]:my-4
-              [&_pre::-webkit-scrollbar]:hidden [&_pre]:overflow-x-auto
-              [&_pre]:rounded-xl [&_pre]:border [&_pre]:border-gray-100 dark:[&_pre]:border-gray-800
-              [&_pre_span[data-line]]:inline-block [&_pre_span[data-line]]:px-5
-              [&_pre_span[data-line]]:text-xs lg:[&_pre_span[data-line]]:text-sm
-              [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded-md
-              [&_code]:bg-gray-100 dark:[&_code]:bg-gray-800"
-            >
-              <PostContent />
-            </div>
-          </div>
-          <Comments />
-        </article>
-        <Footer />
+          <p className="text-sm lg:text-base font-bold">
+            {siteConfig.author.lastName} {siteConfig.author.firstName}
+          </p>
+          <time className="text-xs lg:text-sm text-gray-500 dark:text-gray-400 break-keep" dateTime={post.date}>
+            {formatDate(post.date)}
+          </time>
+          <p className="text-xs lg:text-sm text-gray-500 dark:text-gray-400 break-keep">
+            {post.category}
+          </p>
+        </div>
+        <div className="w-full max-w-full lg:max-w-217.5
+          [&_a:hover]:underline [&_pre]:py-5 [&_pre]:my-4
+          [&_pre::-webkit-scrollbar]:hidden [&_pre]:overflow-x-auto
+          [&_pre]:rounded-xl [&_pre]:border [&_pre]:border-gray-100 dark:[&_pre]:border-gray-800
+          [&_pre_span[data-line]]:inline-block [&_pre_span[data-line]]:px-5
+          [&_pre_span[data-line]]:text-xs lg:[&_pre_span[data-line]]:text-sm
+          [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded-md
+          [&_code]:bg-gray-100 dark:[&_code]:bg-gray-800"
+        >
+          <PostContent />
+        </div>
       </div>
-    </>
+      <Comments />
+    </article>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -59,9 +59,13 @@ export default function RootLayout({
         <SearchProvider>
           <Header />
           <Search />
-          <Footer>
+          <div className="mx-auto my-24 px-4 max-w-331.25
+            flex flex-col
+            lg:grid grid-cols-[1fr_240px] gap-x-12"
+          >
             {children}
-          </Footer>
+            <Footer />
+          </div>
         </SearchProvider>
       </body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+import Header from "@/components/Header";
+import Search from "@/components/Search";
+import Footer from "@/components/Footer";
 import { SearchProvider } from "@/lib/contexts/SearchContext";
 import { siteConfig } from "@/lib/config/site";
 import "./globals.css";
@@ -54,7 +57,11 @@ export default function RootLayout({
     <html lang="ko" className={pretendard.variable}>
       <body>
         <SearchProvider>
-          {children}
+          <Header />
+          <Search />
+          <Footer>
+            {children}
+          </Footer>
         </SearchProvider>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
-import Header from "@/components/Header";
-import Search from "@/components/Search";
-import Footer from "@/components/Footer";
+
 import Button from "@/components/Button";
 import { allPosts } from "@/lib/utils/post";
 import { categories, ALL_CATEGORY_LABEL } from "@/lib/config/categories";
@@ -32,79 +30,69 @@ export default async function Home({
   });
 
   return (
-    <>
-      <Header />
-      <Search />
-      <div className="mx-auto my-24 px-4 max-w-[1325px]
-        flex flex-col
-        lg:grid grid-cols-[1fr_240px] gap-x-12"
+    <div className="flex flex-col gap-4">
+      <h1 className="text-2xl font-bold lg:text-3xl">
+        홈
+      </h1>
+      <div className="w-full select-none
+        flex flex-wrap gap-2"
       >
-        <div className="flex flex-col gap-4">
-          <h1 className="text-2xl font-bold lg:text-3xl">
-            홈
-          </h1>
-          <div className="w-full select-none
-            flex flex-wrap gap-2"
+        {filterOptions.map((option) => (
+          <Link
+            key={option.slug}
+            href={option.slug ? `/?category=${option.slug}` : "/"}
           >
-            {filterOptions.map((option) => (
-              <Link
-                key={option.slug}
-                href={option.slug ? `/?category=${option.slug}` : "/"}
-              >
-                <Button
-                  size="medium"
-                  variant={selectedCategory === option.label ? "filled" : "linear"}
-                >
-                  {option.label}
-                </Button>
-              </Link>
-            ))}
-          </div>
-          <div className="grid grid-cols-1 lg:grid-cols-2
-            gap-x-4 gap-y-5"
-          >
-            {posts.map((post: Post, index: number) => (
-              <article
-                key={post.slug}
-                className="flex flex-col"
-              >
-                <Link
-                  href={`/${post.slug}`}
-                  className="text-inherit no-underline
-                  transition-colors duration-300
-                  hover:p-2 hover:-m-2 hover:rounded-2xl hover:bg-foreground/5"
-                >
-                  <Image
-                    src={post.teaser}
-                    alt={post.title}
-                    width={640}
-                    height={360}
-                    sizes="(max-width: 684px) 100vw,
-                          (max-width: 1324px) 50vw,
-                          33vw"
-                    className="w-full h-auto rounded-lg mb-2"
-                    fetchPriority={index < 4 ? "high" : "low"}
-                    loading={index < 4 ? "eager" : "lazy"}
-                    priority={index < 4}
-                  />
-                  <p className="text-2xs lg:text-xs pb-1">
-                    {post.category}
-                  </p>
-                  <h1 className="text-sm lg:text-base font-bold pb-1">
-                    {post.title}
-                  </h1>
-                  <p className="text-xs lg:text-sm
-                    line-clamp-2 text-gray-500 dark:text-gray-400"
-                  >
-                    {post.excerpt}
-                  </p>
-                </Link>
-              </article>
-            ))}
-          </div>
-        </div>
-        <Footer />
+            <Button
+              size="medium"
+              variant={selectedCategory === option.label ? "filled" : "linear"}
+            >
+              {option.label}
+            </Button>
+          </Link>
+        ))}
       </div>
-    </>
+      <div className="grid grid-cols-1 lg:grid-cols-2
+        gap-x-4 gap-y-5"
+      >
+        {posts.map((post: Post, index: number) => (
+          <article
+            key={post.slug}
+            className="flex flex-col"
+          >
+            <Link
+              href={`/${post.slug}`}
+              className="text-inherit no-underline
+              transition-colors duration-300
+              hover:p-2 hover:-m-2 hover:rounded-2xl hover:bg-foreground/5"
+            >
+              <Image
+                src={post.teaser}
+                alt={post.title}
+                width={640}
+                height={360}
+                sizes="(max-width: 684px) 100vw,
+                      (max-width: 1324px) 50vw,
+                      33vw"
+                className="w-full h-auto rounded-lg mb-2"
+                fetchPriority={index < 4 ? "high" : "low"}
+                loading={index < 4 ? "eager" : "lazy"}
+                priority={index < 4}
+              />
+              <p className="text-2xs lg:text-xs pb-1">
+                {post.category}
+              </p>
+              <h1 className="text-sm lg:text-base font-bold pb-1">
+                {post.title}
+              </h1>
+              <p className="text-xs lg:text-sm
+                line-clamp-2 text-gray-500 dark:text-gray-400"
+              >
+                {post.excerpt}
+              </p>
+            </Link>
+          </article>
+        ))}
+      </div>
+    </div>
   );
 };

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -7,49 +7,39 @@ const socialLinkClass = `inline-flex justify-center items-center p-2
   border border-gray-100 dark:border-gray-800
   hover:bg-foreground/5 transition-colors duration-300`;
 
-export default function Footer({
-  children
-}: {
-  children: React.ReactNode
-}) {
+export default function Footer() {
   return (
-    <div className="mx-auto my-24 px-4 max-w-[1325px]
-      flex flex-col
-      lg:grid grid-cols-[1fr_240px] gap-x-12"
+    <footer className="w-full max-w-60 mx-auto pt-4 lg:pt-12
+      flex flex-col items-center gap-8
+      static lg:fixed lg:right-[calc((100%-1325px)/2+16px)]"
     >
-      {children}
-      <footer className="w-full max-w-60 mx-auto pt-4 lg:pt-12
-        flex flex-col items-center gap-8
-        static lg:fixed lg:right-[calc((100%-1325px)/2+16px)]"
-      >
-        <div className="w-full flex items-center justify-center gap-4 lg:justify-between">
-          {siteConfig.socials.map((link) => (
-            <a
-              key={link.name}
-              href={link.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={link.name}
-              className={socialLinkClass}
-            >
-              <Icon
-                name={link.name}
-                size={20}
-              />
-            </a>
-          ))}
-        </div>
-        <div className="w-full max-w-80 lg:max-w-40
-          bg-gray-400 dark:bg-gray-700 object-contain
-          aspect-32/5 lg:aspect-[1/3.75]
-          [@media(min-width:1325px)_and_(max-height:867px)_and_(min-height:401px)]:aspect-6/5
-          [@media(min-width:1325px)_and_(max-height:400px)_and_(min-height:318px)]:aspect-32/10
-          [@media(min-width:1325px)_and_(max-height:317px)]:aspect-32/5"
-        />
-        <p className="text-xs lg:text-sm text-gray-500 dark:text-gray-400">
-          {siteConfig.copyright}
-        </p>
-      </footer>
-    </div>
+      <div className="w-full flex items-center justify-center gap-4 lg:justify-between">
+        {siteConfig.socials.map((link) => (
+          <a
+            key={link.name}
+            href={link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={link.name}
+            className={socialLinkClass}
+          >
+            <Icon
+              name={link.name}
+              size={20}
+            />
+          </a>
+        ))}
+      </div>
+      <div className="w-full max-w-80 lg:max-w-40
+        bg-gray-400 dark:bg-gray-700 object-contain
+        aspect-32/5 lg:aspect-[1/3.75]
+        [@media(min-width:1325px)_and_(max-height:867px)_and_(min-height:401px)]:aspect-6/5
+        [@media(min-width:1325px)_and_(max-height:400px)_and_(min-height:318px)]:aspect-32/10
+        [@media(min-width:1325px)_and_(max-height:317px)]:aspect-32/5"
+      />
+      <p className="text-xs lg:text-sm text-gray-500 dark:text-gray-400">
+        {siteConfig.copyright}
+      </p>
+    </footer>
   )
 }

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -7,39 +7,49 @@ const socialLinkClass = `inline-flex justify-center items-center p-2
   border border-gray-100 dark:border-gray-800
   hover:bg-foreground/5 transition-colors duration-300`;
 
-export default function Footer() {
+export default function Footer({
+  children
+}: {
+  children: React.ReactNode
+}) {
   return (
-    <footer className="w-full max-w-60 mx-auto pt-4 lg:pt-12
-      flex flex-col items-center gap-8
-      static lg:fixed lg:right-[calc((100%-1325px)/2+16px)]"
+    <div className="mx-auto my-24 px-4 max-w-[1325px]
+      flex flex-col
+      lg:grid grid-cols-[1fr_240px] gap-x-12"
     >
-      <div className="w-full flex items-center justify-center gap-4 lg:justify-between">
-        {siteConfig.socials.map((link) => (
-          <a
-            key={link.name}
-            href={link.href}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label={link.name}
-            className={socialLinkClass}
-          >
-            <Icon
-              name={link.name}
-              size={20}
-            />
-          </a>
-        ))}
-      </div>
-      <div className="w-full max-w-80 lg:max-w-40
-        bg-gray-400 dark:bg-gray-700 object-contain
-        aspect-32/5 lg:aspect-[1/3.75]
-        [@media(min-width:1325px)_and_(max-height:867px)_and_(min-height:401px)]:aspect-6/5
-        [@media(min-width:1325px)_and_(max-height:400px)_and_(min-height:318px)]:aspect-32/10
-        [@media(min-width:1325px)_and_(max-height:317px)]:aspect-32/5"
-      />
-      <p className="text-xs lg:text-sm text-gray-500 dark:text-gray-400">
-        {siteConfig.copyright}
-      </p>
-    </footer>
+      {children}
+      <footer className="w-full max-w-60 mx-auto pt-4 lg:pt-12
+        flex flex-col items-center gap-8
+        static lg:fixed lg:right-[calc((100%-1325px)/2+16px)]"
+      >
+        <div className="w-full flex items-center justify-center gap-4 lg:justify-between">
+          {siteConfig.socials.map((link) => (
+            <a
+              key={link.name}
+              href={link.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={link.name}
+              className={socialLinkClass}
+            >
+              <Icon
+                name={link.name}
+                size={20}
+              />
+            </a>
+          ))}
+        </div>
+        <div className="w-full max-w-80 lg:max-w-40
+          bg-gray-400 dark:bg-gray-700 object-contain
+          aspect-32/5 lg:aspect-[1/3.75]
+          [@media(min-width:1325px)_and_(max-height:867px)_and_(min-height:401px)]:aspect-6/5
+          [@media(min-width:1325px)_and_(max-height:400px)_and_(min-height:318px)]:aspect-32/10
+          [@media(min-width:1325px)_and_(max-height:317px)]:aspect-32/5"
+        />
+        <p className="text-xs lg:text-sm text-gray-500 dark:text-gray-400">
+          {siteConfig.copyright}
+        </p>
+      </footer>
+    </div>
   )
 }


### PR DESCRIPTION
## 연관 Issue
- Closes #69 

## 요약
홈과 글 상세 페이지에 중복돼 있던 `Header`, `Search`, `Footer`와 페이지 컨테이너 마크업을 `app/layout.tsx`로 이동했습니다.

`Footer`가 공통 페이지 컨테이너를 렌더하며 `children`을 감싸는 구조로 변경했고, 각 페이지 컴포넌트는 자신의 콘텐츠만 렌더하도록 정리했습니다.

## 작업 내용
- `app/layout.tsx`에서 `Header`, `Search`를 렌더하도록 변경
- `app/layout.tsx`에서 `children`을 `Footer`로 감싸도록 변경
- `components/Footer/index.tsx`가 `children` props를 받도록 변경
- `Footer`가 공통 페이지 컨테이너(`max-w-[1325px]`, `lg:grid grid-cols-[1fr_240px]`)와 `<footer>` 영역을 함께 렌더하도록 변경
- `app/page.tsx`에서 `Header`, `Search`, `Footer`와 공통 컨테이너 마크업 제거
- `app/page.tsx`의 `Header`, `Search`, `Footer` import 제거
- `app/[slug]/page.tsx`에서 `Header`, `Search`, `Footer`와 공통 컨테이너 마크업 제거
- `app/[slug]/page.tsx`의 `Header`, `Search`, `Footer` import 제거

## 범위
### 포함:
- 공통 레이아웃 요소의 루트 레이아웃 이동
- `Footer`의 공통 페이지 컨테이너 렌더 구조 변경
- 홈/글 상세 페이지의 중복 레이아웃 마크업 제거
- 페이지별 레이아웃 관련 import 정리
### 제외:
- Header/Search/Footer 디자인 변경
- 검색 로직 변경
- 게시물 데이터 계층 변경
- PostCard 등 컴포넌트 추출
- metadata/사이트 설정 변경

## 스크린샷 / 미리 보기