### PR TITLE
[Feat/#66] 커스텀 404 페이지와 에러 바운더리 추가

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -24,7 +24,7 @@ export default function Error({
       <p className="text-sm lg:text-base mt-4">
         맞는 페이지에 오셨는데, 잠시 문제가 생겼나 봐요.
       </p>
-      <Button size="medium" onClick={reset}>
+      <Button size="medium" onClick={reset} className="w-fit">
         다시 시도
       </Button>
     </div>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import Button from "@/components/Button";
+
+export default function Error({
+  error,
+  reset
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+  
+  return (
+    <div className="mx-auto w-full max-w-247.5
+      flex flex-col gap-8 break-keep"
+    >
+      <h1 className="text-2xl font-bold lg:text-3xl">
+        500 - 문제가 발생했어요.
+      </h1>
+      <p className="text-sm lg:text-base mt-4">
+        맞는 페이지에 오셨는데, 잠시 문제가 생겼나 봐요.
+      </p>
+      <Button size="medium" onClick={reset}>
+        다시 시도
+      </Button>
+    </div>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -13,9 +13,7 @@ export default function NotFound() {
         맞는 곳에 오셨는데, 찾는 페이지는 다른 곳에 있나 봐요.
       </p>
       <Link href="/">
-        <Button
-          size="medium"
-          variant="filled"
+        <Button size="medium"
         >
           홈으로 돌아가기
         </Button>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+import Button from "@/components/Button";
+
+export default function NotFound() {
+  return (
+    <div className="mx-auto w-full max-w-247.5
+      flex flex-col gap-8 break-keep"
+    >
+      <h1 className="text-2xl font-bold lg:text-3xl">
+        404 - 페이지를 찾을 수 없어요.
+      </h1>
+      <p className="text-sm lg:text-base mt-4">
+        맞는 곳에 오셨는데, 찾는 페이지는 다른 곳에 있나 봐요.
+      </p>
+      <Link href="/">
+        <Button
+          size="medium"
+          variant="filled"
+        >
+          홈으로 돌아가기
+        </Button>
+      </Link>
+    </div>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -13,8 +13,7 @@ export default function NotFound() {
         맞는 곳에 오셨는데, 찾는 페이지는 다른 곳에 있나 봐요.
       </p>
       <Link href="/">
-        <Button size="medium"
-        >
+        <Button size="medium">
           홈으로 돌아가기
         </Button>
       </Link>


### PR DESCRIPTION
## 연관 Issue
- Closes #66

## 요약
존재하지 않는 경로에 접근했을 때 보여줄 커스텀 404 페이지를 추가했습니다.

클라이언트 런타임 오류가 발생했을 때 사용할 error boundary 페이지도 추가했고, 오류를 콘솔에 기록한 뒤 다시 시도할 수 있도록 처리했습니다.

## 작업 내용
- `app/not-found.tsx` 파일 추가
- 404 페이지 제목과 안내 문구 추가
- 홈으로 돌아가기 링크 추가
- 홈 이동 버튼에 기존 `Button` 컴포넌트 사용
- `app/error.tsx` 파일 추가
- error boundary 컴포넌트를 클라이언트 컴포넌트로 추가
- `useEffect`에서 전달받은 `error`를 `console.error`로 기록하도록 처리
- 500 오류 페이지 제목과 안내 문구 추가
- `reset()`을 호출하는 다시 시도 버튼 추가
- 404/500 페이지 버튼 너비를 `w-fit`으로 정리

## 범위
### 포함:
- 커스텀 404 페이지 추가
- error boundary 페이지 추가
- 404 안내 문구 추가
- 500 안내 문구 추가
- 홈으로 돌아가기 버튼 추가
- 다시 시도 버튼 추가
- 런타임 오류 console logging 처리
### 제외:
- robots/sitemap 구조 변경
- 검색 지연 로드 변경
- 사이트 설정 단일화
- 컴포넌트 타입 정리
- 게시물 meta 검증 변경
- 전체 디자인 개편
- Header/Search/Footer 레이아웃 변경

## 스크린샷 / 미리 보기
<img width="1337" height="885" alt="image" src="https://github.com/user-attachments/assets/b62c18c2-ad97-4c42-a7c7-26d114424aa2" />
<img width="1326" height="874" alt="image" src="https://github.com/user-attachments/assets/d0ac0882-c287-4ad8-b178-88fd8190df9d" />