### PR TITLE
[Refactor/#63] Button 스타일 로직을 공통 헬퍼로 분리

### DIFF
--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -9,6 +9,55 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   iconOnly?: boolean;
 }
 
+const iconOnlySizeStyles: Record<ButtonSize, string> = {
+  tiny: "p-2",
+  small: "p-2.5",
+  medium: "p-3.5",
+  big: "p-4.5",
+};
+
+const sizeStyles: Record<ButtonSize, string> = {
+  tiny: "py-1 px-1 text-2xs lg:text-xs",
+  small: "py-2 px-4 text-2xs lg:text-xs",
+  medium: "py-3 px-5 text-xs lg:text-sm",
+  big: "py-4 px-6 text-sm lg:text-base",
+};
+
+const variantStyles: Record<ButtonVariant, string> = {
+  filled: `bg-foreground text-background
+    border border-foreground
+    hover:bg-foreground/90 hover:text-background/90
+    disabled:bg-gray-200 dark:disabled:bg-gray-800
+    disabled:text-gray-400 dark:disabled:text-gray-600`,
+  linear: `bg-background text-foreground
+    border border-gray-100 dark:border-gray-800
+    hover:bg-foreground/5 disabled:text-gray-400 dark:disabled:text-gray-600`,
+  transparent: `bg-transparent text-foreground
+    hover:bg-foreground/5 disabled:text-gray-400 dark:disabled:text-gray-600`,
+};
+
+const baseStyles = `inline-flex justify-center items-center
+  gap-1.5 rounded-full
+  cursor-pointer select-none
+  disabled:cursor-not-allowed
+  transition-colors duration-300`;
+
+export function buttonClass({
+  size = "medium",
+  variant = "filled",
+  iconOnly = false,
+}: {
+  size?: ButtonSize;
+  variant?: ButtonVariant;
+  iconOnly?: boolean;
+} = {}): string {
+  return cn(
+    iconOnly ? iconOnlySizeStyles[size] : sizeStyles[size],
+    variantStyles[variant],
+    baseStyles,
+  );
+}
+
 export default function Button({
   size = "medium",
   variant = "filled",
@@ -19,47 +68,7 @@ export default function Button({
 }: ButtonProps) {
   return (
     <button
-      className={cn(
-        iconOnly 
-          ? size === "tiny"
-              ? "p-2"
-            : size === "small"
-              ? "p-2.5"
-            : size === "medium"
-              ? "p-3.5"
-            : size === "big"
-              ? "p-4.5"
-            : ""
-          : size === "tiny"
-            ? "py-1 px-1 text-2xs lg:text-xs"
-          : size === "small"
-            ? "py-2 px-4 text-2xs lg:text-xs"
-          : size === "medium"
-            ? "py-3 px-5 text-xs lg:text-sm"
-          : size === "big"
-            ? "py-4 px-6 text-sm lg:text-base"
-          : "",
-        variant === "filled"
-          ? `bg-foreground text-background
-          border border-foreground
-          hover:bg-foreground/90 hover:text-background/90
-          disabled:bg-gray-200 dark:disabled:bg-gray-800
-          disabled:text-gray-400 dark:disabled:text-gray-600`
-        : variant === "linear"
-          ? `bg-background text-foreground
-          border border-gray-100 dark:border-gray-800
-          hover:bg-foreground/5 disabled:text-gray-400 dark:disabled:text-gray-600`
-        : variant === "transparent"
-          ? `bg-transparent text-foreground
-          hover:bg-foreground/5 disabled:text-gray-400 dark:disabled:text-gray-600`
-        : "",
-        `inline-flex justify-center items-center
-        gap-1.5 rounded-full
-        cursor-pointer select-none
-        disabled:cursor-not-allowed
-        transition-colors duration-300`,
-        className
-      )}
+      className={cn(buttonClass({ size, variant, iconOnly }), className)}
       {...props}
     >
       {children}

--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -1,5 +1,13 @@
 import { cn } from "@/lib/utils/cn";
-import ButtonProps from "@/lib/types/button";
+
+export type ButtonSize = "tiny" | "small" | "medium" | "big";
+export type ButtonVariant = "filled" | "linear" | "transparent";
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  size?: ButtonSize;
+  variant?: ButtonVariant;
+  iconOnly?: boolean;
+}
 
 export default function Button({
   size = "medium",

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -1,11 +1,7 @@
 import Icon from "../Icon";
+import { buttonClass } from "../Button";
+import { cn } from "@/lib/utils/cn";
 import { siteConfig } from "@/lib/config/site";
-
-const socialLinkClass = `inline-flex justify-center items-center p-2
-  gap-1.5 rounded-full cursor-pointer select-none
-  bg-background text-foreground
-  border border-gray-100 dark:border-gray-800
-  hover:bg-foreground/5 transition-colors duration-300`;
 
 export default function Footer() {
   return (
@@ -21,7 +17,7 @@ export default function Footer() {
             target="_blank"
             rel="noopener noreferrer"
             aria-label={link.name}
-            className={socialLinkClass}
+            className={cn(buttonClass({ size: "small", variant: "linear" }), "p-2")}
           >
             <Icon
               name={link.name}
@@ -32,7 +28,7 @@ export default function Footer() {
       </div>
       <div className="w-full max-w-80 lg:max-w-40
         bg-gray-400 dark:bg-gray-700 object-contain
-        aspect-32/5 lg:aspect-[1/3.75]
+        aspect-32/5 lg:aspect-1/3.75
         [@media(min-width:1325px)_and_(max-height:867px)_and_(min-height:401px)]:aspect-6/5
         [@media(min-width:1325px)_and_(max-height:400px)_and_(min-height:318px)]:aspect-32/10
         [@media(min-width:1325px)_and_(max-height:317px)]:aspect-32/5"

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import Logo from "../Logo";
 import Icon from "../Icon";
+import { buttonClass } from "../Button";
 import { useSearch } from "@/lib/contexts/SearchContext";
 
 export default function Header() {
@@ -13,7 +14,7 @@ export default function Header() {
       fixed z-20 bg-background
       border-b border-gray-100 dark:border-gray-800"
     >
-      <div className="w-full max-w-[1325px] h-full
+      <div className="w-full max-w-331.25 h-full
         relative mx-auto px-4
         flex items-center justify-between"
       >
@@ -25,11 +26,8 @@ export default function Header() {
         </Link>
         <button
           onClick={openSearch}
-          className="select-none w-6 lg:w-78
-            p-0 lg:px-4 lg:py-2 gap-2.5
-            flex items-center rounded-full
-            lg:border border-gray-100 dark:border-gray-800
-            hover:bg-foreground/5 transition-colors duration-300"
+          className={`w-6 lg:w-78 justify-start
+            ${buttonClass({ size: "small", variant: "linear" })}`}
           aria-label="search"
         >
           <Icon

--- a/lib/types/button.ts
+++ b/lib/types/button.ts
@@ -1,6 +1,0 @@
-export default interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  children?: React.ReactNode;
-  size?: "tiny" | "small" | "medium" | "big";
-  variant?: "filled" | "linear" | "transparent";
-  iconOnly?: boolean;
-}


### PR DESCRIPTION
## 연관 Issue
- Closes #63

## 요약
`Button` 컴포넌트의 스타일 분기 로직을 lookup map 기반으로 정리하고, 버튼 스타일을 재사용할 수 있도록 `buttonClass()` 헬퍼를 추가했습니다.

기존 `lib/types/button.ts`에 있던 Button 타입을 컴포넌트 파일로 옮겼고, Header 검색 버튼과 Footer 소셜 링크도 `buttonClass()`를 사용하도록 변경했습니다.

## 작업 내용
- `ButtonSize` 타입 추가
- `ButtonVariant` 타입 추가
- `ButtonProps` 타입을 `components/Button/index.tsx`로 이동
- `iconOnlySizeStyles` lookup map 추가
- `sizeStyles` lookup map 추가
- `variantStyles` lookup map 추가
- 공통 버튼 class를 `baseStyles`로 분리
- `buttonClass(options)` 헬퍼 추가
- `Button` 컴포넌트가 `buttonClass()`로 className을 계산하도록 변경
- `lib/types/button.ts` 파일 삭제
- `Header` 검색 버튼이 `buttonClass()`를 사용하도록 변경
- `Footer` 소셜 링크가 `buttonClass()`를 사용하도록 변경
- Footer 소셜 링크 class 병합을 위해 `cn` 사용
- Header 내부 컨테이너의 max-width class를 Tailwind spacing class로 정리
- Footer 광고 영역 aspect ratio class를 Tailwind spacing class로 정리

## 범위
### 포함:
- Button 타입 콜로케이션
- Button size 스타일 lookup map 분리
- Button variant 스타일 lookup map 분리
- `buttonClass()` 헬퍼 추가
- 기존 Button 컴포넌트의 class 계산 로직 정리
- `lib/types/button.ts` 제거
- Header 검색 버튼의 Button 스타일 재사용
- Footer 소셜 링크의 Button 스타일 재사용
### 제외:
- PostCard 추출
- 카테고리 필터 중첩 버튼 제거
- Icon 타입 파생
- `lib/types/` 전체 제거
- SearchContext 메모이제이션
- Button 디자인 변경
- Header/Search/Footer 레이아웃 구조 변경

## 스크린샷 / 미리 보기