### PR TITLE
[Refactor/#64] PostCard 컴포넌트 추출 및 홈 필터 구조 개선

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
-import Button from "@/components/Button";
 import PostCard from "@/components/PostCard";
+import { buttonClass } from "@/components/Button";
 import { allPosts } from "@/lib/utils/post";
 import { categories, ALL_CATEGORY_LABEL } from "@/lib/config/categories";
 
@@ -39,13 +39,12 @@ export default async function Home({
           <Link
             key={option.slug}
             href={option.slug ? `/?category=${option.slug}` : "/"}
+            className={buttonClass({
+              size: "medium",
+              variant: selectedCategory === option.label ? "filled" : "linear",
+            })}
           >
-            <Button
-              size="medium"
-              variant={selectedCategory === option.label ? "filled" : "linear"}
-            >
-              {option.label}
-            </Button>
+            {option.label}
           </Link>
         ))}
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,8 @@
 import Link from "next/link";
-import Image from "next/image";
-
 import Button from "@/components/Button";
+import PostCard from "@/components/PostCard";
 import { allPosts } from "@/lib/utils/post";
 import { categories, ALL_CATEGORY_LABEL } from "@/lib/config/categories";
-import Post from "@/lib/types/post";
 
 export default async function Home({
   searchParams
@@ -54,43 +52,12 @@ export default async function Home({
       <div className="grid grid-cols-1 lg:grid-cols-2
         gap-x-4 gap-y-5"
       >
-        {posts.map((post: Post, index: number) => (
-          <article
+        {posts.map((post, index) => (
+          <PostCard
             key={post.slug}
-            className="flex flex-col"
-          >
-            <Link
-              href={`/${post.slug}`}
-              className="text-inherit no-underline
-              transition-colors duration-300
-              hover:p-2 hover:-m-2 hover:rounded-2xl hover:bg-foreground/5"
-            >
-              <Image
-                src={post.teaser}
-                alt={post.title}
-                width={640}
-                height={360}
-                sizes="(max-width: 684px) 100vw,
-                      (max-width: 1324px) 50vw,
-                      33vw"
-                className="w-full h-auto rounded-lg mb-2"
-                fetchPriority={index < 4 ? "high" : "low"}
-                loading={index < 4 ? "eager" : "lazy"}
-                priority={index < 4}
-              />
-              <p className="text-2xs lg:text-xs pb-1">
-                {post.category}
-              </p>
-              <h1 className="text-sm lg:text-base font-bold pb-1">
-                {post.title}
-              </h1>
-              <p className="text-xs lg:text-sm
-                line-clamp-2 text-gray-500 dark:text-gray-400"
-              >
-                {post.excerpt}
-              </p>
-            </Link>
-          </article>
+            post={post}
+            priority={index < 4}
+          />
         ))}
       </div>
     </div>

--- a/components/PostCard/index.tsx
+++ b/components/PostCard/index.tsx
@@ -10,72 +10,74 @@ export interface PostCardProps {
   variant?: PostCardVariant;
 }
 
+function DefaultPostCard({
+  post,
+  priority
+}: {
+  post: Post;
+  priority: boolean
+}) {
+  return (
+    <article className="flex flex-col">
+      <Link
+        href={`/${post.slug}`}
+        className="text-inherit no-underline transition-colors duration-300
+          hover:p-2 hover:-m-2 hover:rounded-2xl hover:bg-foreground/5"
+      >
+        <Image
+          src={post.teaser}
+          alt={post.title}
+          width={640}
+          height={360}
+          sizes="(max-width: 684px) 100vw, (max-width: 1324px) 50vw, 33vw"
+          className="w-full h-auto rounded-lg mb-2"
+          loading={priority ? "eager" : "lazy"}
+          priority={priority}
+        />
+        <p className="text-2xs lg:text-xs pb-1">{post.category}</p>
+        <h2 className="text-sm lg:text-base font-bold pb-1">{post.title}</h2>
+        <p className="text-xs lg:text-sm line-clamp-2 text-gray-500 dark:text-gray-400">
+          {post.excerpt}
+        </p>
+      </Link>
+    </article>
+  );
+}
+
+function CompactPostCard({
+  post
+}: {
+  post: Post
+}) {
+  return (
+    <>
+      <Image
+        src={post.teaser}
+        alt={post.title}
+        width={480}
+        height={480}
+        className="w-10 lg:w-12 h-10 lg:h-12 object-cover rounded-lg"
+      />
+      <article className="flex-1 min-w-0">
+        <div className="text-sm lg:text-base font-bold truncate">
+          {post.title}
+        </div>
+        <div className="text-xs lg:text-sm mt-1 truncate text-gray-500 dark:text-gray-400">
+          {post.excerpt}
+        </div>
+      </article>
+      <div className="text-xs lg:text-sm px-2 py-1 bg-foreground/5 rounded-full">
+        {post.category}
+      </div>
+    </>
+  );
+}
+
 export default function PostCard({
   post,
   priority = false,
-  variant = "default"
+  variant = "default",
 }: PostCardProps) {
-  return (
-    <article className="flex flex-col">
-      {variant === "default" && (
-        <Link
-          href={`/${post.slug}`}
-          className="text-inherit no-underline
-          transition-colors duration-300
-          hover:p-2 hover:-m-2 hover:rounded-2xl hover:bg-foreground/5"
-        >
-          <Image
-            src={post.teaser}
-            alt={post.title}
-            width={640}
-            height={360}
-            sizes="(max-width: 684px) 100vw,
-                  (max-width: 1324px) 50vw,
-                  33vw"
-            className="w-full h-auto rounded-lg mb-2"
-            fetchPriority={priority ? "high" : "low"}
-            loading={priority ? "eager" : "lazy"}
-            priority={priority}
-          />
-          <p className="text-2xs lg:text-xs pb-1">
-            {post.category}
-          </p>
-          <h2 className="text-sm lg:text-base font-bold pb-1">
-            {post.title}
-          </h2>
-          <p className="text-xs lg:text-sm
-            line-clamp-2 text-gray-500 dark:text-gray-400"
-          >
-            {post.excerpt}
-          </p>
-        </Link>
-      ) || (variant === "compact" && (
-        <>
-          <Image
-            src={post.teaser}
-            alt={post.title}
-            width={480}
-            height={480}
-            className="w-10 lg:w-12 h-10 lg:h-12
-              object-cover rounded-lg"
-          />
-          <article className="flex-1 min-w-0">
-            <div className="text-sm lg:text-base font-bold truncate">
-              {post.title}
-            </div>
-            <div className="text-xs lg:text-sm mt-1
-              truncate text-gray-500 dark:text-gray-400"
-            >
-              {post.excerpt}
-            </div>
-          </article>
-          <div className="text-xs lg:text-sm px-2 py-1
-            bg-foreground/5 rounded-full"
-          >
-            {post.category}
-          </div>
-        </>
-      ))}
-    </article>
-  );
+  if (variant === "compact") return <CompactPostCard post={post} />;
+  return <DefaultPostCard post={post} priority={priority} />;
 }

--- a/components/PostCard/index.tsx
+++ b/components/PostCard/index.tsx
@@ -59,16 +59,16 @@ function CompactPostCard({
         className="w-10 lg:w-12 h-10 lg:h-12 object-cover rounded-lg"
       />
       <article className="flex-1 min-w-0">
-        <div className="text-sm lg:text-base font-bold truncate">
+        <h2 className="text-sm lg:text-base font-bold truncate">
           {post.title}
-        </div>
-        <div className="text-xs lg:text-sm mt-1 truncate text-gray-500 dark:text-gray-400">
+        </h2>
+        <p className="text-xs lg:text-sm mt-1 truncate text-gray-500 dark:text-gray-400">
           {post.excerpt}
-        </div>
+        </p>
       </article>
-      <div className="text-xs lg:text-sm px-2 py-1 bg-foreground/5 rounded-full">
+      <span className="text-xs lg:text-sm px-2 py-1 bg-foreground/5 rounded-full">
         {post.category}
-      </div>
+      </span>
     </>
   );
 }

--- a/components/PostCard/index.tsx
+++ b/components/PostCard/index.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import Image from "next/image";
+import type Post from "@/lib/types/post";
+
+export default function PostCard({
+  post,
+  priority = false,
+}: {
+  post: Post;
+  priority?: boolean;
+}) {
+  return (
+    <article className="flex flex-col">
+      <Link
+        href={`/${post.slug}`}
+        className="text-inherit no-underline
+        transition-colors duration-300
+        hover:p-2 hover:-m-2 hover:rounded-2xl hover:bg-foreground/5"
+      >
+        <Image
+          src={post.teaser}
+          alt={post.title}
+          width={640}
+          height={360}
+          sizes="(max-width: 684px) 100vw,
+                (max-width: 1324px) 50vw,
+                33vw"
+          className="w-full h-auto rounded-lg mb-2"
+          fetchPriority={priority ? "high" : "low"}
+          loading={priority ? "eager" : "lazy"}
+          priority={priority}
+        />
+        <p className="text-2xs lg:text-xs pb-1">
+          {post.category}
+        </p>
+        <h2 className="text-sm lg:text-base font-bold pb-1">
+          {post.title}
+        </h2>
+        <p className="text-xs lg:text-sm
+          line-clamp-2 text-gray-500 dark:text-gray-400"
+        >
+          {post.excerpt}
+        </p>
+      </Link>
+    </article>
+  );
+}

--- a/components/PostCard/index.tsx
+++ b/components/PostCard/index.tsx
@@ -2,46 +2,80 @@ import Link from "next/link";
 import Image from "next/image";
 import type Post from "@/lib/types/post";
 
+export type PostCardVariant = "default" | "compact";
+
+export interface PostCardProps {
+  post: Post;
+  priority?: boolean;
+  variant?: PostCardVariant;
+}
+
 export default function PostCard({
   post,
   priority = false,
-}: {
-  post: Post;
-  priority?: boolean;
-}) {
+  variant = "default"
+}: PostCardProps) {
   return (
     <article className="flex flex-col">
-      <Link
-        href={`/${post.slug}`}
-        className="text-inherit no-underline
-        transition-colors duration-300
-        hover:p-2 hover:-m-2 hover:rounded-2xl hover:bg-foreground/5"
-      >
-        <Image
-          src={post.teaser}
-          alt={post.title}
-          width={640}
-          height={360}
-          sizes="(max-width: 684px) 100vw,
-                (max-width: 1324px) 50vw,
-                33vw"
-          className="w-full h-auto rounded-lg mb-2"
-          fetchPriority={priority ? "high" : "low"}
-          loading={priority ? "eager" : "lazy"}
-          priority={priority}
-        />
-        <p className="text-2xs lg:text-xs pb-1">
-          {post.category}
-        </p>
-        <h2 className="text-sm lg:text-base font-bold pb-1">
-          {post.title}
-        </h2>
-        <p className="text-xs lg:text-sm
-          line-clamp-2 text-gray-500 dark:text-gray-400"
+      {variant === "default" && (
+        <Link
+          href={`/${post.slug}`}
+          className="text-inherit no-underline
+          transition-colors duration-300
+          hover:p-2 hover:-m-2 hover:rounded-2xl hover:bg-foreground/5"
         >
-          {post.excerpt}
-        </p>
-      </Link>
+          <Image
+            src={post.teaser}
+            alt={post.title}
+            width={640}
+            height={360}
+            sizes="(max-width: 684px) 100vw,
+                  (max-width: 1324px) 50vw,
+                  33vw"
+            className="w-full h-auto rounded-lg mb-2"
+            fetchPriority={priority ? "high" : "low"}
+            loading={priority ? "eager" : "lazy"}
+            priority={priority}
+          />
+          <p className="text-2xs lg:text-xs pb-1">
+            {post.category}
+          </p>
+          <h2 className="text-sm lg:text-base font-bold pb-1">
+            {post.title}
+          </h2>
+          <p className="text-xs lg:text-sm
+            line-clamp-2 text-gray-500 dark:text-gray-400"
+          >
+            {post.excerpt}
+          </p>
+        </Link>
+      ) || (variant === "compact" && (
+        <>
+          <Image
+            src={post.teaser}
+            alt={post.title}
+            width={480}
+            height={480}
+            className="w-10 lg:w-12 h-10 lg:h-12
+              object-cover rounded-lg"
+          />
+          <article className="flex-1 min-w-0">
+            <div className="text-sm lg:text-base font-bold truncate">
+              {post.title}
+            </div>
+            <div className="text-xs lg:text-sm mt-1
+              truncate text-gray-500 dark:text-gray-400"
+            >
+              {post.excerpt}
+            </div>
+          </article>
+          <div className="text-xs lg:text-sm px-2 py-1
+            bg-foreground/5 rounded-full"
+          >
+            {post.category}
+          </div>
+        </>
+      ))}
     </article>
   );
 }

--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import Image from "next/image";
 import Icon from "../Icon";
 import Button from "../Button";
 import Post from "@/lib/types/post";
+import PostCard from "../PostCard";
 import useSearchDialog from "@/lib/hooks/search";
 import { useSearch } from "@/lib/contexts/SearchContext";
 
@@ -133,29 +133,11 @@ export default function Search() {
                     onClick={() => navigateToPost(post.slug)}
                     onMouseEnter={() => handleMouseEnterItem(index)}
                   >
-                    <Image
-                      src={post.teaser}
-                      alt={post.title}
-                      width={480}
-                      height={480}
-                      className="w-10 lg:w-12 h-10 lg:h-12
-                        object-cover rounded-lg"
+                    <PostCard
+                      post={post}
+                      priority={index < 4}
+                      variant="compact"
                     />
-                    <article className="flex-1 min-w-0">
-                      <div className="text-sm lg:text-base font-bold truncate">
-                        {post.title}
-                      </div>
-                      <div className="text-xs lg:text-sm mt-1
-                        truncate text-gray-500 dark:text-gray-400"
-                      >
-                        {post.excerpt}
-                      </div>
-                    </article>
-                    <div className="text-xs lg:text-sm px-2 py-1
-                      bg-foreground/5 rounded-full"
-                    >
-                      {post.category}
-                    </div>
                   </button>
                 ))}
                 {hasMore && (

--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -135,7 +135,6 @@ export default function Search() {
                   >
                     <PostCard
                       post={post}
-                      priority={index < 4}
                       variant="compact"
                     />
                   </button>


### PR DESCRIPTION
## 연관 Issue
- Closes #64

## 요약
홈 페이지에 직접 작성돼 있던 게시물 카드 마크업을 `PostCard` 컴포넌트로 분리했습니다.

기본 카드와 검색 결과용 compact 카드 렌더링을 함께 처리하도록 구성했고, 홈 카테고리 필터의 `Link > Button` 중첩 구조도 단일 링크 스타일로 정리했습니다.

## 작업 내용
- `components/PostCard/index.tsx` 파일 추가
- `PostCardVariant` 타입 추가
- `PostCardProps` 인터페이스 추가
- 기본 게시물 카드 렌더링을 `DefaultPostCard`로 분리
- 검색 결과용 compact 카드 렌더링을 `CompactPostCard`로 분리
- `PostCard`가 `post`, `priority`, `variant` props를 받도록 구현
- 기본 카드에서 기존 홈 카드와 동일한 Link, Image, category, title, excerpt 구조 렌더링
- 기본 카드 제목 태그를 `h1`에서 `h2`로 변경
- compact 카드에서 검색 결과 썸네일, 제목, excerpt, category 렌더링
- `app/page.tsx`의 게시물 카드 마크업을 `PostCard` 사용으로 변경
- 홈 게시물 목록에서 `priority={index < 4}`를 `PostCard`로 전달하도록 변경
- `app/page.tsx`의 `next/image`, `Button`, `Post` import 제거
- 카테고리 필터의 `Link > Button` 중첩 구조 제거
- 카테고리 필터 Link가 `buttonClass()`를 className으로 사용하도록 변경
- `components/Search/index.tsx`의 검색 결과 프리뷰 마크업을 `PostCard` compact variant 사용으로 변경
- Search 컴포넌트에서 직접 사용하던 `next/image` import 제거

## 범위
### 포함:
- `PostCard` 컴포넌트 추가
- 홈 게시물 카드 마크업 컴포넌트화
- 검색 결과 게시물 프리뷰 마크업 컴포넌트화
- 기본/compact 카드 variant 분리
- 홈 카테고리 필터의 중첩 버튼 제거
- 카테고리 필터 링크의 `buttonClass()` 적용
- 홈 페이지와 Search 컴포넌트의 import 정리
### 제외:
- Button `buttonClass()` 최초 도입
- Post/PostMeta 타입 이동
- 카테고리 설정 파일 도입
- 검색 데이터 로드 구조 변경
- 게시물 데이터 로더 변경
- 카드 디자인 변경
- Search 동작 변경

## 스크린샷 / 미리 보기