### PR TITLE
[Refactor/#65] SearchContext 핸들러와 value 메모이제이션

### DIFF
--- a/lib/contexts/SearchContext.tsx
+++ b/lib/contexts/SearchContext.tsx
@@ -2,13 +2,13 @@
 
 import { createContext, useCallback, useContext, useMemo, useState, ReactNode } from "react";
 
-export interface Search {
+export interface SearchContextValue {
   isOpen: boolean;
   openSearch: () => void;
   closeSearch: () => void;
 }
 
-const SearchContext = createContext<Search | undefined>(undefined);
+const SearchContext = createContext<SearchContextValue | undefined>(undefined);
 
 export function SearchProvider({
   children

--- a/lib/contexts/SearchContext.tsx
+++ b/lib/contexts/SearchContext.tsx
@@ -36,7 +36,7 @@ export function useSearch() {
   const context = useContext(SearchContext);
 
   if (!context) {
-    throw new Error("useSearch must be used within SearchProvider");
+    throw new Error("useSearch는 SearchProvider 안에서만 사용될 수 있습니다.");
   }
 
   return context;

--- a/lib/contexts/SearchContext.tsx
+++ b/lib/contexts/SearchContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useState, ReactNode } from "react";
+import { createContext, useCallback, useContext, useMemo, useState, ReactNode } from "react";
 import { Search } from "@/lib/types/context";
 
 const SearchContext = createContext<Search | undefined>(undefined);
@@ -12,11 +12,16 @@ export function SearchProvider({
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
-  const openSearch = () => setIsOpen(true);
-  const closeSearch = () => setIsOpen(false);
+  const openSearch = useCallback(() => setIsOpen(true), []);
+  const closeSearch = useCallback(() => setIsOpen(false), []);
+
+  const value = useMemo(
+    () => ({ isOpen, openSearch, closeSearch }),
+    [isOpen, openSearch, closeSearch],
+  );
 
   return (
-    <SearchContext.Provider value={{ isOpen, openSearch, closeSearch }}>
+    <SearchContext.Provider value={value}>
       {children}
     </SearchContext.Provider>
   );

--- a/lib/contexts/SearchContext.tsx
+++ b/lib/contexts/SearchContext.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { createContext, useCallback, useContext, useMemo, useState, ReactNode } from "react";
-import { Search } from "@/lib/types/context";
+
+export interface Search {
+  isOpen: boolean;
+  openSearch: () => void;
+  closeSearch: () => void;
+}
 
 const SearchContext = createContext<Search | undefined>(undefined);
 

--- a/lib/types/context.ts
+++ b/lib/types/context.ts
@@ -1,5 +1,0 @@
-export interface Search {
-  isOpen: boolean;
-  openSearch: () => void;
-  closeSearch: () => void;
-}


### PR DESCRIPTION
## 연관 Issue
- Closes #65 

## 요약
`SearchContext`의 `openSearch`, `closeSearch` 핸들러를 `useCallback`으로 감싸 참조가 불필요하게 바뀌지 않도록 변경했습니다.

Context value도 `useMemo`로 메모이제이션하고, 기존 `lib/types/context.ts`에 있던 Search 타입을 `SearchContext.tsx`로 이동했습니다.

## 작업 내용
- `lib/contexts/SearchContext.tsx`에서 `useCallback`, `useMemo` import 추가
- `Search` 인터페이스를 `SearchContext.tsx`로 이동
- `openSearch`를 `useCallback(() => setIsOpen(true), [])`로 변경
- `closeSearch`를 `useCallback(() => setIsOpen(false), [])`로 변경
- `SearchContext.Provider`에 전달하는 value를 `useMemo()`로 생성하도록 변경
- value 의존성에 `isOpen`, `openSearch`, `closeSearch` 추가
- `lib/types/context.ts` 파일 삭제

## 범위
### 포함:
- `SearchContext` 핸들러 메모이제이션
- `SearchContext` value 메모이제이션
- `Search` 인터페이스 콜로케이션
- `lib/types/context.ts` 제거
- 기존 `SearchProvider` API 유지
### 제외:
- Search 인덱스 지연 로드 변경
- Search UI 변경
- Header 검색 버튼 변경
- 검색 알고리즘 변경
- SearchContext 외 다른 타입 정리

## 스크린샷 / 미리 보기