### PR TITLE
[Design/#76] 반응형 브레이크포인트 재정의 및 중간 뷰포트 레이아웃 개선

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -81,7 +81,7 @@ export default async function Post({
       <Image
         src={post.teaser}
         alt={`Teaser image for ${post.title}`}
-        sizes="(max-width: 684px) 100vw,
+        sizes="(max-width: 674px) 100vw,
               70vw"
         className="w-full h-auto"
         fetchPriority="high"

--- a/app/globals.css
+++ b/app/globals.css
@@ -118,8 +118,9 @@
   --font-weight-bold: 700;
   --font-weight-extrabold: 800;
 
-  --breakpoint-sm: 42.75rem;
-  --breakpoint-lg: 82.75rem;
+  --breakpoint-sm: 39.625rem;
+  --breakpoint-md: 42.125rem;
+  --breakpoint-lg: 60.25rem;
 
   @keyframes slide {
     from {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -61,7 +61,7 @@ export default function RootLayout({
           <Search />
           <div className="mx-auto my-24 px-4 max-w-331.25
             flex flex-col
-            lg:grid grid-cols-[1fr_240px] gap-x-12"
+            md:grid grid-cols-[1fr_240px] gap-x-12"
           >
             {children}
             <Footer />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,7 +28,9 @@ export default async function Home({
   });
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="mx-auto w-full max-w-247.5
+      flex flex-col gap-4"
+    >
       <h1 className="text-2xl font-bold lg:text-3xl">
         홈
       </h1>

--- a/components/Footer/index.tsx
+++ b/components/Footer/index.tsx
@@ -7,7 +7,7 @@ export default function Footer() {
   return (
     <footer className="w-full max-w-60 mx-auto pt-4 lg:pt-12
       flex flex-col items-center gap-8
-      static lg:fixed lg:right-[calc((100%-1325px)/2+16px)]"
+      static md:sticky md:top-24 md:self-start"
     >
       <div className="w-full flex items-center justify-center gap-4 lg:justify-between">
         {siteConfig.socials.map((link) => (
@@ -26,12 +26,12 @@ export default function Footer() {
           </a>
         ))}
       </div>
-      <div className="w-full max-w-80 lg:max-w-40
+      <div className="w-full max-w-80 md:max-w-40
         bg-gray-400 dark:bg-gray-700 object-contain
-        aspect-32/5 lg:aspect-1/3.75
-        [@media(min-width:1325px)_and_(max-height:867px)_and_(min-height:401px)]:aspect-6/5
-        [@media(min-width:1325px)_and_(max-height:400px)_and_(min-height:318px)]:aspect-32/10
-        [@media(min-width:1325px)_and_(max-height:317px)]:aspect-32/5"
+        aspect-32/5 md:aspect-1/3.75
+        [@media(min-width:674px)_and_(max-height:867px)_and_(min-height:401px)]:aspect-6/5
+        [@media(min-width:674px)_and_(max-height:400px)_and_(min-height:318px)]:aspect-32/10
+        [@media(min-width:674px)_and_(max-height:317px)]:aspect-32/5"
       />
       <p className="text-xs lg:text-sm text-gray-500 dark:text-gray-400">
         {siteConfig.copyright}

--- a/components/PostCard/index.tsx
+++ b/components/PostCard/index.tsx
@@ -29,7 +29,7 @@ function DefaultPostCard({
           alt={post.title}
           width={640}
           height={360}
-          sizes="(max-width: 684px) 100vw, (max-width: 1324px) 50vw, 33vw"
+          sizes="(max-width: 674px) 100vw, (max-width: 834px) 50vw, 33vw"
           className="w-full h-auto rounded-lg mb-2"
           loading={priority ? "eager" : "lazy"}
           priority={priority}

--- a/components/PostCard/index.tsx
+++ b/components/PostCard/index.tsx
@@ -29,7 +29,7 @@ function DefaultPostCard({
           alt={post.title}
           width={640}
           height={360}
-          sizes="(max-width: 674px) 100vw, (max-width: 834px) 50vw, 33vw"
+          sizes="(max-width: 674px) 100vw, (max-width: 964px) 70vw, 33vw"
           className="w-full h-auto rounded-lg mb-2"
           loading={priority ? "eager" : "lazy"}
           priority={priority}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -131,7 +131,7 @@ const components: MDXComponents = {
       <Image
         src={src}
         alt={alt ?? ""}
-        sizes="(max-width: 684px) 100vw,
+        sizes="(max-width: 674px) 100vw,
               70vw"
         className="w-full h-auto"
         fetchPriority="low"


### PR DESCRIPTION
## 연관 Issue
- Closes #76 

## 요약
Tailwind 테마 브레이크포인트를 재정의하고(`sm` 634px, `md` 674px 신설, `lg` 964px), 2단 그리드 전환 시점을 `lg`에서 `md`로 앞당겨 중간 뷰포트에서도 사이드 푸터가 있는 적응형 레이아웃이 동작하도록 변경했습니다.

사이드 푸터는 `fixed` + 위치 계산 방식에서 `sticky` 기반으로 변경했고, 이미지 `sizes` 속성을 새 브레이크포인트에 맞게 조정했습니다.

## 작업 내용
- `app/globals.css`의 `--breakpoint-sm`을 42.75rem에서 39.625rem으로 변경
- `app/globals.css`에 `--breakpoint-md: 42.125rem` 추가
- `app/globals.css`의 `--breakpoint-lg`를 82.75rem에서 60.25rem으로 변경
- `app/layout.tsx`의 2단 그리드 전환 접두사를 `lg:`에서 `md:`로 변경
- `app/page.tsx`의 홈 콘텐츠 컨테이너에 `mx-auto w-full max-w-247.5` 적용
- `components/Footer/index.tsx`의 포지셔닝을 `lg:fixed lg:right-[calc((100%-1325px)/2+16px)]`에서 `md:sticky md:top-24 md:self-start`로 변경
- Footer 광고 영역의 `max-w`, `aspect` 접두사를 `lg:`에서 `md:`로 변경
- Footer 광고 영역의 화면 높이별 aspect 분기 기준을 `min-width:1325px`에서 `min-width:674px`로 변경
- `components/PostCard/index.tsx`의 이미지 `sizes`를 `(max-width: 674px) 100vw, (max-width: 834px) 50vw, 33vw`로 변경
- `mdx-components.tsx`의 본문 이미지 `sizes`를 `(max-width: 674px) 100vw, 70vw`로 변경

## 범위
### 포함:
- 반응형 브레이크포인트 재정의
- 2단 그리드 전환 시점 변경
- 홈 콘텐츠 최대 폭과 중앙 정렬 적용
- Footer sticky 포지셔닝 전환
- Footer 광고 영역 반응형 분기 기준 변경
- 이미지 `sizes` 브레이크포인트 조정
### 제외:
- 색상, 타이포그래피 등 시각 스타일 변경
- Header/Search 레이아웃 변경
- 컴포넌트 구조 리팩토링
- 게시물 데이터 계층 변경
- 모바일(1열) 레이아웃 구성 변경

## 스크린샷 / 미리 보기
<img width="723" height="966" alt="image" src="https://github.com/user-attachments/assets/406cc558-2b70-4340-861d-d333468126fc" />
<img width="920" height="765" alt="image" src="https://github.com/user-attachments/assets/d73fa947-1a93-41a5-92ca-22f02ae9d814" />