### PR TITLE
[Refactor/#83] 게시물 로딩 책임 분리 및 요약 데이터 흐름 정리

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -1,16 +1,13 @@
-import { notFound } from "next/navigation";
 import Image from "next/image";
 import MeCard from "@/components/MeCard";
 import Comments from "@/components/Comments";
-import { allPosts } from "@/lib/utils/post";
+import { getPost, getPostSummary, getPostList } from "@/lib/posts/service";
 import { siteConfig } from "@/lib/config/site";
 
-export async function generateStaticParams() {
-  const base = await allPosts();
+export const dynamicParams = false;
 
-  return base.map((post) => ({
-    slug: post.slug,
-  }));
+export async function generateStaticParams() {
+  return getPostList().then((posts) => posts.map(({ slug }) => ({ slug })));
 }
 
 export async function generateMetadata({
@@ -19,35 +16,31 @@ export async function generateMetadata({
   slug: string
 }> }) {
   const { slug } = await params;
-  const base = await allPosts();
-  const post = base.find((post) => (
-    post.slug === slug
-  ));
-
-  if (!post) {
-    return {};
-  }
+  const [{ title, teaser }, { excerpt }] = await Promise.all([
+    getPost(slug),
+    getPostSummary(slug),
+  ]);
 
   return {
-    title: post.title,
-    description: post.excerpt,
+    title,
+    description: excerpt,
     openGraph: {
       type: "website",
       url: `${siteConfig.url}/${slug}`,
-      title: post.title,
-      description: post.excerpt,
+      title,
+      description: excerpt,
       siteName: siteConfig.name,
       images: [{
-        url: post.teaser.src,
+        url: teaser.src,
       }],
     },
     twitter: {
       card: "summary_large_image",
-      site: `${siteConfig.url}/${slug}`,
-      title: post.title,
-      description: post.excerpt,
+      site: siteConfig.url,
+      title,
+      description: excerpt,
       images: [{
-        url: post.teaser.src,
+        url: teaser.src,
       }],
     },
   };
@@ -60,27 +53,19 @@ export default async function Post({
 }> }) {
   const { slug } = await params;
 
-  const base = await allPosts();
-  const post = base.find((post) => (
-    post.slug === slug
-  ));
-
-  if (!post) {
-    notFound();
-  }
-
-  const PostContent = (await import(`@/posts/${post.slug}/post.mdx`)).default;
+  // dynamicParams=false라 미등록 slug는 여기 도달 전 404 — 로딩 실패는 그대로 드러낸다
+  const { title, Content, date, category, teaser } = await getPost(slug);
 
   return (
     <article className="mx-auto w-full max-w-247.5
       flex flex-col gap-8 break-keep"
     >
       <h1 className="text-2xl font-bold lg:text-3xl">
-        {post.title}
+        {title}
       </h1>
       <Image
-        src={post.teaser}
-        alt={`Teaser image for ${post.title}`}
+        src={teaser}
+        alt={`${title} 티저 사진`}
         sizes="(max-width: 674px) 100vw,
               70vw"
         className="w-full h-auto"
@@ -90,7 +75,7 @@ export default async function Post({
       <div className="flex flex-col-reverse gap-8
         lg:grid grid-cols-[100px_1fr] gap-x-7"
       >
-        <MeCard date={post.date} category={post.category} />
+        <MeCard date={date} category={category} />
         <div className="w-full max-w-full lg:max-w-217.5
           [&_a:hover]:underline [&_pre]:py-5 [&_pre]:my-4
           [&_pre::-webkit-scrollbar]:hidden [&_pre]:overflow-x-auto
@@ -100,7 +85,7 @@ export default async function Post({
           [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded-md
           [&_code]:bg-gray-100 dark:[&_code]:bg-gray-800"
         >
-          <PostContent />
+          <Content />
         </div>
       </div>
       <Comments />

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -16,10 +16,7 @@ export async function generateMetadata({
   slug: string
 }> }) {
   const { slug } = await params;
-  const [{ title, teaser }, { excerpt }] = await Promise.all([
-    getPost(slug),
-    getPostSummary(slug),
-  ]);
+  const { title, teaser, excerpt } = await getPostSummary(slug);
 
   return {
     title,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import PostCard from "@/components/PostCard";
 import { buttonClass } from "@/components/Button";
-import { allPosts } from "@/lib/utils/post";
+import { getPostSummaries } from "@/lib/posts/service";
 import { categories, ALL_CATEGORY_LABEL } from "@/lib/config/categories";
 
 export default async function Home({
@@ -21,7 +21,7 @@ export default async function Home({
     filterOptions.find((c) => c.slug === category || c.label === category)?.label
       ?? ALL_CATEGORY_LABEL;
 
-  const base = await allPosts();
+  const base = await getPostSummaries();
   const posts = base.filter((post) => {
     if (selectedCategory === ALL_CATEGORY_LABEL) return true;
     return post.category === selectedCategory;

--- a/app/posts/route.ts
+++ b/app/posts/route.ts
@@ -1,7 +1,7 @@
-import { allPosts } from "@/lib/utils/post";
+import { getPostSummaries } from "@/lib/posts/service";
 
 export const dynamic = "force-static";
 
 export async function GET() {
-  return Response.json(await allPosts());
+  return Response.json(await getPostSummaries());
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,9 +1,9 @@
 import type { MetadataRoute } from "next";
-import { allPosts } from "@/lib/utils/post";
+import { getPostList } from "@/lib/posts/service";
 import { siteConfig } from "@/lib/config/site";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const posts = await allPosts();
+  const posts = await getPostList();
 
   const postRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
     url: `${siteConfig.url}/${post.slug}`,

--- a/components/PostCard/index.tsx
+++ b/components/PostCard/index.tsx
@@ -1,11 +1,14 @@
 import Link from "next/link";
 import Image from "next/image";
-import type { Post } from "@/lib/utils/post";
+import type { PostSummary } from "@/lib/utils/post";
 
 export type PostCardVariant = "default" | "compact";
 
+// 카드 렌더에 필요한 필드만 요구 — 검색 전문(content)은 불필요
+type PostCardPost = Omit<PostSummary, "content">;
+
 export interface PostCardProps {
-  post: Post;
+  post: PostCardPost;
   priority?: boolean;
   variant?: PostCardVariant;
 }
@@ -14,7 +17,7 @@ function DefaultPostCard({
   post,
   priority
 }: {
-  post: Post;
+  post: PostCardPost;
   priority: boolean
 }) {
   return (
@@ -47,7 +50,7 @@ function DefaultPostCard({
 function CompactPostCard({
   post
 }: {
-  post: Post
+  post: PostCardPost
 }) {
   return (
     <>

--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -4,17 +4,17 @@ import { useState, useEffect, useCallback } from "react";
 import Icon from "../Icon";
 import Button from "../Button";
 import PostCard from "../PostCard";
-import type { Post } from "@/lib/utils/post";
+import type { PostSummary } from "@/lib/utils/post";
 import useSearchDialog from "@/lib/hooks/search";
 import { useSearch } from "@/lib/contexts/SearchContext";
 
-let searchDocsCache: Post[] | null = null;
+let searchDocsCache: PostSummary[] | null = null;
 
 type LoadState = "idle" | "loaded" | "error";
 
 export default function Search() {
   const { isOpen } = useSearch();
-  const [docs, setDocs] = useState<Post[]>(searchDocsCache ?? []);
+  const [docs, setDocs] = useState<PostSummary[]>(searchDocsCache ?? []);
   const [loadState, setLoadState] = useState<LoadState>(searchDocsCache ? "loaded" : "idle");
 
   const loadDocs = useCallback(async () => {
@@ -29,7 +29,7 @@ export default function Search() {
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
       }
-      const data: Post[] = await res.json();
+      const data: PostSummary[] = await res.json();
       searchDocsCache = data;
       setDocs(data);
       setLoadState("loaded");

--- a/lib/hooks/search.ts
+++ b/lib/hooks/search.ts
@@ -2,10 +2,10 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import type { Post } from "@/lib/utils/post";
+import type { PostSummary } from "@/lib/utils/post";
 import { useSearch } from "@/lib/contexts/SearchContext";
 
-export default function useSearchDialog(allPosts: Post[]) {
+export default function useSearchDialog(summaries: PostSummary[]) {
   const router = useRouter();
 
   const dialogRef = useRef<HTMLDialogElement>(null);
@@ -18,7 +18,7 @@ export default function useSearchDialog(allPosts: Post[]) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [displayCount, setDisplayCount] = useState(6);
 
-  const filteredPosts = allPosts.filter(
+  const filteredPosts = summaries.filter(
     (post) =>
       post.title.toLowerCase().includes(searchKeyword.toLowerCase()) ||
       post.content.toLowerCase().includes(searchKeyword.toLowerCase())

--- a/lib/posts/service.ts
+++ b/lib/posts/service.ts
@@ -1,0 +1,41 @@
+import { cache } from "react";
+import { loadPost, readPostSummary, readSlugs, type Post, type PostSummary } from "@/lib/utils/post";
+
+// 소비자는 이 파일만 import하면 되도록 타입 재노출
+export type { Post, PostMeta, PostSummary } from "@/lib/utils/post";
+
+const byDateDesc = (a: Post, b: Post) =>
+  new Date(b.date).getTime() - new Date(a.date).getTime();
+
+// 게시물 하나 (요청 단위 중복 로딩 방지)
+export const getPost = cache(loadPost);
+
+// 게시물 전체 목록 — 병렬 로딩 후 최신순 정렬, 검증 오류는 모아서 한 번에 보고
+export const getPostList = cache(async (): Promise<Post[]> => {
+  const slugs = await readSlugs();
+  const results = await Promise.allSettled(slugs.map(getPost));
+
+  const errors = results
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) =>
+      result.reason instanceof Error ? result.reason.message : String(result.reason)
+    );
+  if (errors.length > 0) {
+    throw new Error(`게시글 로딩 실패 (${errors.length}건):\n${errors.sort().join("\n")}`);
+  }
+
+  return results
+    .map((result) => (result as PromiseFulfilledResult<Post>).value)
+    .sort(byDateDesc);
+});
+
+// 게시물 하나의 검색/미리보기용 요약
+export const getPostSummary = cache(async (slug: string): Promise<PostSummary> =>
+  readPostSummary(await getPost(slug))
+);
+
+// 전체 요약 목록 — 검색 인덱스·홈 카드용 (getPostList의 최신순 정렬 유지)
+export const getPostSummaries = cache(async (): Promise<PostSummary[]> => {
+  const posts = await getPostList();
+  return Promise.all(posts.map(readPostSummary));
+});

--- a/lib/utils/post.ts
+++ b/lib/utils/post.ts
@@ -1,9 +1,9 @@
 import type { StaticImageData } from "next/image";
-import { cache } from "react";
-import { readdir, readFile } from "fs/promises";
+import type { ComponentType } from "react";
 import path from "path";
+import { readdir, readFile } from "fs/promises";
 import { toExcerpt, toPlainText } from "@/lib/utils/text";
-import { validatePostMeta } from "@/lib/utils/meta"
+import { validatePostMeta } from "@/lib/utils/meta";
 
 export interface PostMeta {
   teaser: StaticImageData;
@@ -14,57 +14,51 @@ export interface PostMeta {
 
 export interface Post extends PostMeta {
   slug: string;
+  Content: ComponentType;
+}
+
+// 검색·카드 미리보기용 — 직렬화 가능한 필드만 (컴포넌트 미포함)
+export interface PostSummary extends PostMeta {
+  slug: string;
   content: string;
   excerpt: string;
 }
 
-export const allPosts = cache(async function (): Promise<Post[]> {
-  // `.mdx` 파일 저장 경로 선언
-  const postPath = path.resolve(process.cwd(), "posts");
+const POSTS_DIR = path.resolve(process.cwd(), "posts");
 
-  // 게시물 폴더 모두 가져오기
-  const dir = await readdir(postPath, { withFileTypes: true });
-  const files = dir.filter((file) => file.isDirectory());
+// posts/ 하위 디렉터리명 = slug 목록
+export async function readSlugs(): Promise<string[]> {
+  const dirents = await readdir(POSTS_DIR, { withFileTypes: true });
+  return dirents
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => dirent.name);
+}
 
-  const errors: string[] = [];
-  const posts: Post[] = [];
+// posts/{slug}/post.mdx 동적 import + 메타 검증
+export async function loadPost(slug: string): Promise<Post> {
+  // MDX 모듈의 default export가 본문 컴포넌트
+  const { default: Content, meta } = await import(`@/posts/${slug}/post.mdx`);
 
-  // 각 게시물의 메타데이터 및 경로 정보 반환
-  await Promise.all(
-    files.map(async (file) => {
-      // 슬러그 생성
-      const slug = file.name;
-
-      // 메타데이터는 MDX 모듈의 `meta` export에서 추출
-      const { meta } = await import(`@/posts/${slug}/post.mdx`);
-
-      const metaErrors = validatePostMeta(slug, meta);
-      if (metaErrors.length > 0) {
-        errors.push(...metaErrors);
-        return;
-      }
-
-      // 글 내용 추출 (상단의 import/export 선언 제거)
-      const raw = await readFile(path.join(postPath, slug, "post.mdx"), "utf-8");
-      const content = toPlainText(raw);
-      const excerpt = toExcerpt(content);
-
-      posts.push({
-        slug,
-        content,
-        excerpt,
-        ...meta,
-      });
-    })
-  );
-
+  const errors = validatePostMeta(slug, meta);
   if (errors.length > 0) {
-    throw new Error(
-      `게시글 메타데이터 검증 실패 (${errors.length}건):\n${errors.sort().join("\n")}`
-    );
+    throw new Error(`[${slug}] 메타데이터 검증 실패:\n${errors.join("\n")}`);
   }
 
-  posts.sort((a, b) => +new Date(b.date) - +new Date(a.date));
+  return { slug, Content, ...(meta as PostMeta) };
+}
 
-  return posts;
-});
+// 원문 → 플레인 텍스트/발췌 (검색·미리보기용)
+export async function readPostSummary(post: Post): Promise<PostSummary> {
+  const raw = await readFile(path.join(POSTS_DIR, post.slug, "post.mdx"), "utf-8");
+  const content = toPlainText(raw);
+
+  return {
+    slug: post.slug,
+    title: post.title,
+    category: post.category,
+    teaser: post.teaser,
+    date: post.date,
+    content,
+    excerpt: toExcerpt(content),
+  };
+}


### PR DESCRIPTION
## 연관 Issue
- Closes #83

## 요약
`allPosts()`에 몰려 있던 게시물 로딩 책임을 slug 목록, 단일 게시물, 검색/미리보기 요약 데이터 흐름으로 분리했습니다.

홈, 검색 인덱스, sitemap, 글 상세 페이지가 각자 필요한 게시물 서비스 함수만 사용하도록 정리했고, 카드와 검색 훅은 게시물 요약 데이터 기준으로 타입을 맞췄습니다.

## 작업 내용
- `lib/utils/post.ts`에서 `readSlugs`, `loadPost`, `readPostSummary` 함수 추가
- 상세 렌더링용 `Post` 타입을 MDX `Content` 컴포넌트 중심으로 정리
- 검색/카드/인덱스용 `PostSummary` 타입 추가
- `lib/posts/service.ts` 파일 추가
- `getPost`, `getPostList`, `getPostSummary`, `getPostSummaries` 서비스 함수 추가
- `getPostList()`에서 병렬 로딩, 오류 집계, 최신순 정렬 처리
- `app/page.tsx`가 `getPostSummaries()`를 사용하도록 변경
- `app/posts/route.ts`가 `getPostSummaries()` 결과를 반환하도록 변경
- `app/sitemap.ts`가 `getPostList()`를 사용하도록 변경
- `app/[slug]/page.tsx`가 `getPost`, `getPostSummary`, `getPostList`를 사용하도록 변경
- `app/[slug]/page.tsx`에 `dynamicParams = false` 추가
- 글 상세 본문이 MDX `Content` 컴포넌트를 직접 렌더하도록 변경
- `components/PostCard/index.tsx`가 카드 렌더링에 필요한 필드만 요구하도록 타입 조정
- `components/Search/index.tsx`와 `lib/hooks/search.ts`를 게시물 요약 타입 기준으로 변경

## 범위
### 포함:
- 게시물 로딩 책임 분리
- 게시물 서비스 계층 추가
- 홈/검색 인덱스/sitemap/글 상세 페이지의 게시물 서비스 사용
- `Post`와 `PostSummary` 타입 분리
- 카드와 검색 관련 타입 정리
### 제외:
- `posts/*/post.mdx` 원본 수정
- 콘텐츠 저장소 분리 및 외부 fetch 전환
- Cloudflare Workers 전환 작업
- OpenNext/wrangler 설정 변경
- 검색 UI 변경
- 카드 디자인 변경
- 댓글/Giscus 설정 변경

## 스크린샷 / 미리 보기