### PR TITLE
[Fix/#84] `yarn lint`의 react-hooks/set-state-in-effect 오류 해결

### DIFF
--- a/components/Search/index.tsx
+++ b/components/Search/index.tsx
@@ -40,9 +40,13 @@ export default function Search() {
 
   // 다이얼로그가 처음 열릴 때 검색 인덱스 지연 로드
   useEffect(() => {
-    if (isOpen && loadState === "idle") {
-      loadDocs();
-    }
+    if (!isOpen || loadState !== "idle") return;
+
+    const timer = window.setTimeout(() => {
+      void loadDocs();
+    }, 0);
+
+    return () => window.clearTimeout(timer);
   }, [isOpen, loadState, loadDocs]);
 
   const {

--- a/lib/hooks/search.ts
+++ b/lib/hooks/search.ts
@@ -47,6 +47,12 @@ export default function useSearchDialog(allPosts: Post[]) {
     setDisplayCount(6);
   }, [closeSearch]);
 
+  const handleSearchKeywordChange = useCallback((keyword: string) => {
+    setSearchKeyword(keyword);
+    setSelectedIndex(0);
+    setDisplayCount(6);
+  }, []);
+
   const navigateToPost = useCallback((slug: string) => {
     router.push(`/${slug}`);
     handleClose();
@@ -109,11 +115,6 @@ export default function useSearchDialog(allPosts: Post[]) {
     });
   }, [selectedIndex]);
 
-  useEffect(() => {
-    setSelectedIndex(0);
-    setDisplayCount(6);
-  }, [searchKeyword]);
-
   const handleLoadMore = () => {
     setDisplayCount((prev) => prev + 6);
   };
@@ -132,7 +133,7 @@ export default function useSearchDialog(allPosts: Post[]) {
     inputRef,
     itemRefs,
     searchKeyword,
-    setSearchKeyword,
+    setSearchKeyword: handleSearchKeywordChange,
     selectedIndex,
     displayedPosts,
     hasMore,


### PR DESCRIPTION
## 연관 Issue
- Closes #84

## 요약
`yarn lint`에서 발생하던 `react-hooks/set-state-in-effect` 오류를 해결했습니다.

검색 인덱스 지연 로드는 effect 안에서 비동기로 예약되도록 바꾸고, 검색어 변경 시 선택 인덱스와 표시 개수를 초기화하는 로직은 입력 핸들러 쪽으로 이동했습니다.

## 작업 내용
- `components/Search/index.tsx`의 검색 인덱스 지연 로드 effect에서 `loadDocs()`를 `setTimeout`으로 예약하도록 변경
- effect cleanup에서 예약된 timer를 정리하도록 처리
- `lib/hooks/search.ts`에 `handleSearchKeywordChange` 추가
- 검색어 변경 시 `searchKeyword`, `selectedIndex`, `displayCount`를 함께 갱신하도록 변경
- `searchKeyword` 변경을 감지해 상태를 초기화하던 effect 제거
- `yarn lint` 오류 없음 확인

## 범위
### 포함:
- `react-hooks/set-state-in-effect` 린트 오류 해결
- 검색 인덱스 최초 열림 시 지연 로드 동작 유지
- 검색어 변경 시 선택 인덱스와 표시 개수 초기화 유지
### 제외:
- 검색 UI 변경
- 검색 알고리즘 변경
- `/posts` 응답 데이터 구조 변경
- 게시물 로딩 서비스 구조 변경
- `mdx-components.tsx`의 `<img>` warning 처리

## 스크린샷 / 미리 보기